### PR TITLE
Always have a DigestStorage

### DIFF
--- a/dht/src/main/java/net/tomp2p/dht/PeerBuilderDHT.java
+++ b/dht/src/main/java/net/tomp2p/dht/PeerBuilderDHT.java
@@ -63,6 +63,8 @@ public class PeerBuilderDHT {
 		if (storageLayer == null) {
 			storageLayer = new StorageLayer(storage);
 			storageLayer.start(peer.connectionBean().timer(), storageLayer.storageCheckIntervalMillis());
+		}
+		if (peer.peerBean().digestStorage() == null) {
 			peer.peerBean().digestStorage(storageLayer);
 		}
 		if (storageRPC == null) {


### PR DESCRIPTION
Setting a custom StorageLayer caused in not having any DigestStorage.
This caused errors when removing data from the DHT.
