### PR TITLE
Fix null pointer exception when sending self-messages

### DIFF
--- a/core/src/main/java/net/tomp2p/connection/Sender.java
+++ b/core/src/main/java/net/tomp2p/connection/Sender.java
@@ -387,6 +387,8 @@ public class Sender {
 	 * @param message the request
 	 */
 	public void sendSelf(final FutureResponse futureResponse, final Message message) {
+		message.convertKeyCollections();
+
 		LOG.debug("Handle message that is intended for the sender itself {}", message);
 		final DispatchHandler handler = dispatcher.associatedHandler(message);
 		handler.forwardMessage(message, null, new Responder() {

--- a/core/src/main/java/net/tomp2p/message/KeyCollection.java
+++ b/core/src/main/java/net/tomp2p/message/KeyCollection.java
@@ -80,7 +80,7 @@ public class KeyCollection {
         return this;
     }
 
-    private Collection<Number640> convert(final KeyCollection k) {
+    public static Collection<Number640> convert(final KeyCollection k) {
         final Collection<Number640> keys3;
         if (k.keysConvert != null) {
             keys3 = new ArrayList<Number640>(k.keysConvert.size());

--- a/core/src/main/java/net/tomp2p/message/Message.java
+++ b/core/src/main/java/net/tomp2p/message/Message.java
@@ -768,7 +768,24 @@ public class Message {
         }
         return keyCollectionList.get(index);
     }
-    
+
+    public void convertKeyCollections() {
+        if (keyCollectionList == null) {
+            return;
+        }
+        ArrayList<KeyCollection> newKeyCollectionList = new ArrayList<>(keyCollectionList.size());
+        for (KeyCollection keyCollection : keyCollectionList) {
+            newKeyCollectionList.add(convertKeyCollection(keyCollection));
+        }
+        keyCollectionList = newKeyCollectionList;
+    }
+
+    private KeyCollection convertKeyCollection(KeyCollection keyCollection) {
+        return keyCollection.isConvert()
+                ? new KeyCollection(KeyCollection.convert(keyCollection))
+                : keyCollection;
+    }
+
     public Message keyMap640Keys(final KeyMap640Keys keyMap) {
         if (!presetContentTypes) {
             contentType(Content.MAP_KEY640_KEYS);


### PR DESCRIPTION
Messages sent to self are not serialized and then decoded
and the code receiving messages assumes that 
KeyCollection.keys is not null.  This change performs
the conversion on Sender.sendSelf as a workaround.
