### PR TITLE
RTT measurements, customizable priorities for routing and customizable kademlia bucket sizes.

### DIFF
--- a/core/src/main/java/net/tomp2p/connection/PeerBean.java
+++ b/core/src/main/java/net/tomp2p/connection/PeerBean.java
@@ -26,6 +26,7 @@ import net.tomp2p.peers.Number160;
 import net.tomp2p.peers.PeerAddress;
 import net.tomp2p.peers.PeerMap;
 import net.tomp2p.peers.PeerStatusListener;
+import net.tomp2p.peers.RTT;
 import net.tomp2p.rpc.BloomfilterFactory;
 import net.tomp2p.storage.DigestStorage;
 import net.tomp2p.storage.DigestTracker;
@@ -137,10 +138,10 @@ public class PeerBean {
         return peerStatusListeners;
     }
     
-    public PeerBean notifyPeerFound(PeerAddress sender, PeerAddress reporter, PeerConnection peerConnection) {
+    public PeerBean notifyPeerFound(PeerAddress sender, PeerAddress reporter, PeerConnection peerConnection, RTT roundTripTime) {
     	synchronized (peerStatusListeners) {
     		for (PeerStatusListener peerStatusListener : peerStatusListeners) {
-    			peerStatusListener.peerFound(sender, reporter, peerConnection);
+    			peerStatusListener.peerFound(sender, reporter, peerConnection, roundTripTime);
     		}
     	}
     	return this;

--- a/core/src/main/java/net/tomp2p/connection/RequestHandler.java
+++ b/core/src/main/java/net/tomp2p/connection/RequestHandler.java
@@ -15,17 +15,18 @@
  */
 package net.tomp2p.connection;
 
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.SimpleChannelInboundHandler;
-import net.tomp2p.futures.FutureResponse;
-import net.tomp2p.message.Message;
-import net.tomp2p.message.MessageID;
-import net.tomp2p.peers.PeerAddress;
-import net.tomp2p.peers.PeerStatusListener;
-import net.tomp2p.rpc.RPC;
+ import io.netty.channel.ChannelHandlerContext;
+ import io.netty.channel.SimpleChannelInboundHandler;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+ import net.tomp2p.futures.FutureResponse;
+ import net.tomp2p.message.Message;
+ import net.tomp2p.message.MessageID;
+ import net.tomp2p.peers.PeerAddress;
+ import net.tomp2p.peers.PeerStatusListener;
+ import net.tomp2p.rpc.RPC;
+
+ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
 
 /**
  * Is able to send UDP messages (as a request) and processes incoming replies. It is important that this class handles
@@ -282,11 +283,14 @@ public class RequestHandler<K extends FutureResponse> extends SimpleChannelInbou
         	responseMessage.sender(realAddress);
         }
 
+        // Stop time measurement of RTT
+        futureResponse.stopRTTMeasurement();
+
         // We got a good answer, let's mark the sender as alive
         //if its an announce, the peer status will be handled in the RPC
 		if (responseMessage.command() != RPC.Commands.LOCAL_ANNOUNCE.getNr() 
 				&& (responseMessage.isOk() || responseMessage.isNotOk())) {
-			peerBean.notifyPeerFound(responseMessage.sender(), null, null);
+			peerBean.notifyPeerFound(responseMessage.sender(), null, null, futureResponse.getRoundTripTime());
 		}
         
         // call this for streaming support

--- a/core/src/main/java/net/tomp2p/connection/Sender.java
+++ b/core/src/main/java/net/tomp2p/connection/Sender.java
@@ -153,6 +153,9 @@ public class Sender {
 		
 		removePeerIfFailed(futureResponse, message);
 
+        // RTT calculation
+        futureResponse.startRTTMeasurement(false);
+
 		final ChannelFuture channelFuture;
 		if (peerConnection != null && peerConnection.channelFuture() != null && peerConnection.channelFuture().channel().isActive()) {
 			channelFuture = sendTCPPeerConnection(peerConnection, handler, channelCreator, futureResponse);
@@ -577,6 +580,9 @@ public class Sender {
 				LOG.debug("No hole punching possible, because There is no PeerNAT.");
 			}
 		}
+
+        // RTT calculation
+        futureResponse.startRTTMeasurement(true);
 
 		try {
 			final ChannelFuture channelFuture;

--- a/core/src/main/java/net/tomp2p/futures/FutureResponse.java
+++ b/core/src/main/java/net/tomp2p/futures/FutureResponse.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CountDownLatch;
 
 import net.tomp2p.connection.ProgresHandler;
 import net.tomp2p.message.Message;
+import net.tomp2p.peers.RTT;
 
 /**
  * Each response has one request messages. The corresponding response message is set only if the request has been
@@ -45,6 +46,8 @@ public class FutureResponse extends BaseFutureImpl<FutureResponse> {
     private final CountDownLatch secondProgressHandler = new CountDownLatch(1);
     
     private boolean reponseLater = false;
+
+    private final RTT roundTripTime = new RTT();
 
     /**
      * Create the future and set the request message.
@@ -279,11 +282,35 @@ public class FutureResponse extends BaseFutureImpl<FutureResponse> {
             }
         }
     }
+
+    /**
+     * Start measuring time until reply is recieved
+     *
+     * @return True if time has successfully been started
+     *         False if measurement already has been stopped
+     */
+    public boolean startRTTMeasurement(boolean isUDP) {
+        return getRoundTripTime().beginTimeMeasurement(isUDP);
+    }
+
+    /**
+     * Stops time measurement for the round trip time
+     *
+     * @return True if some valid time was recorded, False if time has not yet
+     *         been started or already been stopped
+     */
+    public boolean stopRTTMeasurement() {
+        return getRoundTripTime().stopTimeMeasurement();
+    }
     
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("future response state:");
         sb.append(",type:").append(type.name()).append(",msg:").append(requestMessage.command()).append(",reason:").append(reason);
         return sb.toString();
+    }
+
+    public RTT getRoundTripTime() {
+        return roundTripTime;
     }
 }

--- a/core/src/main/java/net/tomp2p/p2p/DefaultPeerStatisticComparator.java
+++ b/core/src/main/java/net/tomp2p/p2p/DefaultPeerStatisticComparator.java
@@ -1,0 +1,19 @@
+package net.tomp2p.p2p;
+
+import java.util.Comparator;
+
+import net.tomp2p.peers.Number160;
+import net.tomp2p.peers.PeerMap;
+import net.tomp2p.peers.PeerStatistic;
+
+/**
+ * Default Comparator for PeerStatistics. Compares XOR distance to location.
+ *
+ * Created by Sebastian Stephan on 28.12.14.
+ */
+public class DefaultPeerStatisticComparator implements PeerStatisticComparator {
+    @Override
+    public Comparator<PeerStatistic> getComparator(Number160 location) {
+        return PeerMap.createXORStatisticComparator(location);
+    }
+}

--- a/core/src/main/java/net/tomp2p/p2p/PeerStatisticComparator.java
+++ b/core/src/main/java/net/tomp2p/p2p/PeerStatisticComparator.java
@@ -1,0 +1,19 @@
+package net.tomp2p.p2p;
+
+import java.util.Comparator;
+
+import net.tomp2p.peers.Number160;
+import net.tomp2p.peers.PeerStatistic;
+
+/**
+ * Interface used by the PeerMap. Must return a Comparator that compares
+ * two PeerStatistic objects based on how close they are to a a given location.
+ *
+ * The Comparator must never return 0 for PeerStatistics with equal
+ * PeerID. Breaking ties with the complete XOR distance ensures this property.
+ *
+ * Created by Sebastian Stephan on 26.12.14.
+ */
+public interface PeerStatisticComparator {
+    public Comparator<PeerStatistic> getComparator(Number160 location);
+}

--- a/core/src/main/java/net/tomp2p/p2p/RTTPeerStatisticComparator.java
+++ b/core/src/main/java/net/tomp2p/p2p/RTTPeerStatisticComparator.java
@@ -1,0 +1,60 @@
+package net.tomp2p.p2p;
+
+import java.util.Comparator;
+
+import net.tomp2p.peers.Number160;
+import net.tomp2p.peers.PeerMap;
+import net.tomp2p.peers.PeerStatistic;
+
+/**
+ * A sample class class used by the routing mechanism to prioritise peers with
+ * a low latency during routing.
+ *
+ * First sorting criteria is bit distance measured in equal high-bits. Closer peers
+ * are prioritised.
+ *
+ * Second sorting criteria is the availability of RTT information. Peers with RTT
+ * measurements are prioritised.
+ *
+ * Third sorting criteria is the average RTT. Faster responding peers are prioritised.
+ *
+ * The last tie-breaker is the complete XOR distance.
+ *
+ * It is important to never let the comparator return 0 for non-equal peer addresses,
+ * as this would conflict with the usage of the comparator in the TreeSet, where
+ * the comparator returning 0 means that both entries are equal.
+ *
+ * Created by Sebastian Stephan on 06.12.14.
+ */
+public class RTTPeerStatisticComparator implements PeerStatisticComparator {
+    @Override
+    public Comparator<PeerStatistic> getComparator(final Number160 location) {
+        return new Comparator<PeerStatistic>() {
+            @Override
+            public int compare(PeerStatistic o1, PeerStatistic o2) {
+                // Ensure consistency with equals
+                if (o1.peerAddress().equals(o2.peerAddress())) return 0;
+
+                // First sort by bucket distance
+                int firstComp = PeerMap.classCloser(location, o1.peerAddress(), o2.peerAddress());
+                if (firstComp == 0) {
+                    // Second sort by "is rtt available"
+                    if (o1.getMeanRTT() < 0 && o2.getMeanRTT() >= 0) {
+                        return 1;
+                    } else if (o1.getMeanRTT() >= 0 && o2.getMeanRTT() < 0) {
+                        return -1;
+                    } else if (o1.getMeanRTT() >= 0 && o2.getMeanRTT() >= 0 && o1.getMeanRTT() != o2.getMeanRTT()) {
+                        // Third sort by rtt if they are different)
+                        Long rtt1 = o1.getMeanRTT();
+                        Long rtt2 = o2.getMeanRTT();
+                        return rtt1.compareTo(rtt2);
+                    }
+                    // Last sort by true xor distance (will never be 0)
+                    return PeerMap.isKadCloser(location, o1.peerAddress(), o2.peerAddress());
+                } else {
+                    return firstComp;
+                }
+            }
+        };
+    }
+}

--- a/core/src/main/java/net/tomp2p/p2p/Statistics.java
+++ b/core/src/main/java/net/tomp2p/p2p/Statistics.java
@@ -38,7 +38,6 @@ public class Statistics {
 	}
 	
 	public double estimatedNumberOfNodes() {
-		final int bagSize = peerMap.bagSizeVerified();
 		final List<Map<Number160, PeerStatistic>> map = peerMap.peerMapVerified();
 		// assume we are full
 		double gap = 0D;
@@ -47,13 +46,13 @@ public class Statistics {
 			Map<Number160, PeerStatistic> peers = map.get(i);
 			final int numPeers = peers.size();
 
-			if (numPeers > 0 && numPeers < bagSize) {
+			if (numPeers > 0 && numPeers < peerMap.bagSizeVerified(i)) {
 				double currentGap = Math.pow(2, i) / numPeers;
 				gap += currentGap * numPeers;
 				gapCount += numPeers;
 			} else if (numPeers == 0) {
 				// we are empty
-			} else if (numPeers == bagSize) {
+			} else if (numPeers == peerMap.bagSizeVerified(i)) {
 				// we are full
 			}
 		}

--- a/core/src/main/java/net/tomp2p/p2p/UpdatableTreeSet.java
+++ b/core/src/main/java/net/tomp2p/p2p/UpdatableTreeSet.java
@@ -1,0 +1,30 @@
+package net.tomp2p.p2p;
+
+import java.util.Comparator;
+import java.util.TreeSet;
+
+/**
+ * A TreeSet that allows for updates. When the item is already in the Set,
+ * the item is removed before adding it.
+ *
+ * Created by Sebastian Stephan on 10.12.14.
+ */
+public class UpdatableTreeSet<E> extends TreeSet<E> {
+
+    /**
+     * Creates a new empty PriorityQueueSet with the given comparator
+     * @param comparator
+     */
+    public UpdatableTreeSet(Comparator<? super E> comparator) {
+        super(comparator);
+    }
+
+    @Override
+    public boolean add(E e) {
+        while (contains(e)) {
+            remove(e);
+        }
+        return super.add(e);
+    }
+
+}

--- a/core/src/main/java/net/tomp2p/peers/LocalMap.java
+++ b/core/src/main/java/net/tomp2p/peers/LocalMap.java
@@ -49,7 +49,7 @@ public class LocalMap implements Maintainable, PeerStatusListener {
     }
 
 	@Override
-    public boolean peerFound(PeerAddress remotePeer, PeerAddress referrer, PeerConnection peerConnection) {
+    public boolean peerFound(PeerAddress remotePeer, PeerAddress referrer, PeerConnection peerConnection, RTT roundTripTime) {
 		//do nothing, here we get to know all the peers, we are interested only in those we have stored
         return false;
     }
@@ -63,7 +63,7 @@ public class LocalMap implements Maintainable, PeerStatusListener {
         
         if (firstHand || secondHand) {
             offlineMap.remove(remotePeer.peerId());
-            PeerStatistic peerStatatistic = PeerMap.updateExistingVerifiedPeerAddress(localMap, remotePeer, firstHand);
+            PeerStatistic peerStatatistic = PeerMap.updateExistingVerifiedPeerAddress(localMap, remotePeer, firstHand, null);
             if(peerStatatistic == null) {
             	peerStatatistic = new PeerStatistic(remotePeer);
             	localMap.put(remotePeer.peerId(), peerStatatistic);

--- a/core/src/main/java/net/tomp2p/peers/PeerMap.java
+++ b/core/src/main/java/net/tomp2p/peers/PeerMap.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
@@ -29,6 +30,7 @@ import java.util.TreeSet;
 import net.tomp2p.connection.PeerConnection;
 import net.tomp2p.connection.PeerException;
 import net.tomp2p.connection.PeerException.AbortCause;
+import net.tomp2p.p2p.PeerStatisticComparator;
 import net.tomp2p.utils.CacheMap;
 import net.tomp2p.utils.ConcurrentCacheMap;
 
@@ -45,8 +47,8 @@ public class PeerMap implements PeerStatusListener, Maintainable {
     private static final Logger LOG = LoggerFactory.getLogger(PeerMap.class);
 
     // each distance bit has its own bag this is the size of the verified peers (the ones that we know are reachable)
-    private final int bagSizeVerified;
-    private final int bagSizeOverflow;
+    private final int[] bagSizesVerified;
+    private final int[] bagSizesOverflow;
 
     // the id of this node
     private final Number160 self;
@@ -73,6 +75,8 @@ public class PeerMap implements PeerStatusListener, Maintainable {
     
     private final boolean peerVerification;
 
+    private PeerStatisticComparator peerStatisticComparator;
+
     /**
      * Creates the bag for the peers. This peer knows a lot about close peers and the further away the peers are, the
      * less known they are. Distance is measured with XOR of the peer ID. The distance of peer with ID 0x12 and peer
@@ -87,34 +91,45 @@ public class PeerMap implements PeerStatusListener, Maintainable {
         if (self == null || self.isZero()) {
             throw new IllegalArgumentException("Zero or null are not a valid IDs");
         }
-        this.bagSizeVerified = peerMapConfiguration.bagSizeVerified();
-        this.bagSizeOverflow = peerMapConfiguration.bagSizeOverflow();
+        this.bagSizesVerified = peerMapConfiguration.getVerifiedBagSizes();
+        this.bagSizesOverflow = peerMapConfiguration.getOverflowBagSizes();
         this.offlineCount = peerMapConfiguration.offlineCount();
         this.peerFilters = peerMapConfiguration.peerFilters();
-        this.peerMapVerified = initFixedMap(bagSizeVerified, false);
-        this.peerMapOverflow = initFixedMap(bagSizeOverflow, true);
+        this.peerMapVerified = initMap(bagSizesVerified, false);
+        this.peerMapOverflow = initMap(bagSizesOverflow, true);
         // bagSizeVerified * Number160.BITS should be enough
         this.offlineMap = new ConcurrentCacheMap<Number160, PeerAddress>(
-                peerMapConfiguration.offlineTimeout(), bagSizeVerified * Number160.BITS);
+                peerMapConfiguration.offlineTimeout(), totalNumberOfVerifiedBags());
         this.shutdownMap = new ConcurrentCacheMap<Number160, PeerAddress>(
-                peerMapConfiguration.shutdownTimeout(), bagSizeVerified * Number160.BITS);
+                peerMapConfiguration.shutdownTimeout(), totalNumberOfVerifiedBags());
         this.exceptionMap = new ConcurrentCacheMap<Number160, PeerAddress>(
-                peerMapConfiguration.exceptionTimeout(), bagSizeVerified * Number160.BITS);
+                peerMapConfiguration.exceptionTimeout(), totalNumberOfVerifiedBags());
         this.maintenance = peerMapConfiguration.maintenance().init(peerMapVerified, peerMapOverflow,
                 offlineMap, shutdownMap, exceptionMap);
         this.peerVerification = peerMapConfiguration.isPeerVerification();
+        this.peerStatisticComparator = peerMapConfiguration.getPeerStatisticComparator();
+
+    }
+
+    private int totalNumberOfVerifiedBags() {
+        int sum = 0;
+        for (int i=0; i<Number160.BITS; i++) {
+            sum += bagSizesVerified[i];
+        }
+        return sum;
     }
 
     /**
-     * Create a fixed size bag with an unmodifiable map.
-     * 
-     * @param bagSize
-     *            The bag size
+     * Create a list of bag with an unmodifiable map.
+     *
+     * @param bagSizes
+     *            The bag sizes
      * @param caching
      *            If a caching map should be created
+     *
      * @return The list of bags containing an unmodifiable map
      */
-    private List<Map<Number160, PeerStatistic>> initFixedMap(final int bagSize, final boolean caching) {
+    private List<Map<Number160, PeerStatistic>> initMap(final int[] bagSizes, final boolean caching) {
         List<Map<Number160, PeerStatistic>> tmp = new ArrayList<Map<Number160, PeerStatistic>>();
         for (int i = 0; i < Number160.BITS; i++) {
             // I made some experiments here and concurrent sets are not
@@ -126,9 +141,9 @@ public class PeerMap implements PeerStatusListener, Maintainable {
             //
             // We also only allocate memory for the bags far away, as they are likely to be filled first.
             if (caching) {
-                tmp.add(new CacheMap<Number160, PeerStatistic>(bagSize, true));
+                tmp.add(new CacheMap<Number160, PeerStatistic>(bagSizes[i], true));
             } else {
-                final int memAlloc = Math.max(0, bagSize - (Number160.BITS - i));
+                final int memAlloc = Math.max(0, bagSizes[i] / 8 - 1);
                 tmp.add(new HashMap<Number160, PeerStatistic>(memAlloc));
             }
         }
@@ -255,10 +270,13 @@ public class PeerMap implements PeerStatusListener, Maintainable {
      * @param referrer
      *            If we had direct contact and we know for sure that this node is online, we set firsthand to true.
      *            Information from 3rd party peers are always second hand and treated as such
+     * @param roundTripTime
+     *            A RTT object, that measured the round-trip-time related to the finding of this peer. This is
+     *            will be saved into the PeerStatistic
      * @return True if the neighbor could be added or updated, otherwise false.
      */
     @Override
-    public boolean peerFound(final PeerAddress remotePeer, final PeerAddress referrer, final PeerConnection peerConnection) {    	
+    public boolean peerFound(final PeerAddress remotePeer, final PeerAddress referrer, final PeerConnection peerConnection, RTT roundTripTime) {
     	LOG.debug("peer {} is online reporter was {}", remotePeer, referrer);
         boolean firstHand = referrer == null;
         //if we got contacted by this peer, but we did not initiate the connection
@@ -302,13 +320,13 @@ public class PeerMap implements PeerStatusListener, Maintainable {
         
         final int classMember = classMember(remotePeer.peerId());
 
-        // the peer might have a new port
-        final PeerStatistic oldPeerStatatistic = updateExistingVerifiedPeerAddress(
-                peerMapVerified.get(classMember), remotePeer, firstHand);
-        if (oldPeerStatatistic != null) {
+        // Update existing PeerStatistic with RTT info and potential new port
+        final PeerStatistic oldPeerStatistic = updateExistingVerifiedPeerAddress(
+                peerMapVerified.get(classMember), remotePeer, firstHand, roundTripTime);
+        if (oldPeerStatistic != null) {
             // we update the peer, so we can exit here and report that we have
             // updated it.
-            notifyUpdate(remotePeer, oldPeerStatatistic);
+            notifyUpdate(remotePeer, oldPeerStatistic);
             return true;
         } else {
             if (firstHand || (secondHand && !peerVerification)) {
@@ -317,12 +335,13 @@ public class PeerMap implements PeerStatusListener, Maintainable {
                 synchronized (map) {
                     // check again, now we are synchronized
                     if (map.containsKey(remotePeer.peerId())) {
-                        return peerFound(remotePeer, referrer, peerConnection);
+                        return peerFound(remotePeer, referrer, peerConnection, roundTripTime);
                     }
-                    if (map.size() < bagSizeVerified) {
-                        final PeerStatistic peerStatatistic = new PeerStatistic(remotePeer);
-                        peerStatatistic.successfullyChecked();
-                        map.put(remotePeer.peerId(), peerStatatistic);
+                    if (map.size() < bagSizesVerified[classMember]) {
+                        final PeerStatistic peerStatistic = new PeerStatistic(remotePeer);
+                        peerStatistic.successfullyChecked();
+                        peerStatistic.addRTT(roundTripTime);
+                        map.put(remotePeer.peerId(), peerStatistic);
                         insterted = true;
                     }
                 }
@@ -342,14 +361,18 @@ public class PeerMap implements PeerStatusListener, Maintainable {
         // check if we have it stored in the non verified map.
         final Map<Number160, PeerStatistic> mapOverflow = peerMapOverflow.get(classMember);
         synchronized (mapOverflow) {
-            PeerStatistic peerStatatistic = mapOverflow.get(remotePeer.peerId());
-            if (peerStatatistic == null) {
-                peerStatatistic = new PeerStatistic(remotePeer);
+            PeerStatistic peerStatistic = mapOverflow.get(remotePeer.peerId());
+            if (peerStatistic == null) {
+                peerStatistic = new PeerStatistic(remotePeer);
             }
             if (firstHand) {
-                peerStatatistic.successfullyChecked();
+                peerStatistic.successfullyChecked();
+                peerStatistic.addRTT(roundTripTime);
             }
-            mapOverflow.put(remotePeer.peerId(), peerStatatistic);
+            if (thirdHand && roundTripTime != null) {
+                peerStatistic.addRTT(roundTripTime.setEstimated());
+            }
+            mapOverflow.put(remotePeer.peerId(), peerStatistic);
         }
 
         notifyInsert(remotePeer, false);
@@ -362,8 +385,6 @@ public class PeerMap implements PeerStatusListener, Maintainable {
      * 
      * @param remotePeer
      *            The node that should be removed
-     * @param force
-     *            A flag that removes a peer immediately.
      * @return True if the neighbor was removed and added to a cache list. False if peer has not been removed or is
      *         already in the peer removed temporarily list.
      */
@@ -394,15 +415,15 @@ public class PeerMap implements PeerStatusListener, Maintainable {
             tmp = peerMapVerified.get(classMember);
             if (tmp != null) {
                 boolean removed = false;
-                final PeerStatistic peerStatatistic;
+                final PeerStatistic peerStatistic;
                 synchronized (tmp) {
-                    peerStatatistic = tmp.remove(remotePeer.peerId());
-                    if (peerStatatistic != null) {
+                    peerStatistic = tmp.remove(remotePeer.peerId());
+                    if (peerStatistic != null) {
                         removed = true;
                     }
                 }
                 if (removed) {
-                    notifyRemove(remotePeer, peerStatatistic);
+                    notifyRemove(remotePeer, peerStatistic);
                     return true;
                 }
             }
@@ -455,13 +476,39 @@ public class PeerMap implements PeerStatusListener, Maintainable {
             return tmp.containsKey(peerAddress.peerId());
         }
     }
+
+    /**
+     * Checks if an entry of that peerAddress is available in the verified peer map
+     * or overflow peer map.
+     * @param peerAddress
+     * @return The PeerStatistic or null if peer is not in peer map
+     */
+    public PeerStatistic getPeerStatistic(final PeerAddress peerAddress) {
+        PeerStatistic peerStatistic;
+        final int classMember = classMember(peerAddress.peerId());
+        if (classMember == -1) {
+            // -1 means we searched for ourself and we never are our neighbor
+            return null;
+        }
+
+        // Try to find PeerStatistic in verified Map
+        peerStatistic = peerMapVerified().get(classMember).get(peerAddress.peerId());
+
+        // If that failed, look in the overflow map
+        if (peerStatistic == null) {
+            peerStatistic = peerMapOverflow().get(classMember).get(peerAddress.peerId());
+        }
+
+        return peerStatistic;
+
+    }
     
     /**
      * Returns close peers to the peer itself.
      * @param atLeast The number we want to find at least
      * @return A sorted set with close peers first in this set.
      */
-    public NavigableSet<PeerAddress> closePeers(final int atLeast) {
+    public NavigableSet<PeerStatistic> closePeers(final int atLeast) {
         return closePeers(self, atLeast);
     }
 
@@ -475,12 +522,17 @@ public class PeerMap implements PeerStatusListener, Maintainable {
      *            The number we want to find at least
      * @return A sorted set with close peers first in this set. Use set.first() to get the closest peer
      */
-    public NavigableSet<PeerAddress> closePeers(final Number160 id, final int atLeast) {
-    	return closePeers(self(), id, atLeast, peerMapVerified);
+    public NavigableSet<PeerStatistic> closePeers(final Number160 id, final int atLeast) {
+    	return closePeers(self(), id, atLeast, peerMapVerified, peerStatisticComparator.getComparator(id));
     }
 
-    public static NavigableSet<PeerAddress> closePeers(final Number160 self, final Number160 other, final int atLeast, List<Map<Number160, PeerStatistic>> peerMap) {
-        final NavigableSet<PeerAddress> set = new TreeSet<PeerAddress>(createComparator(other));
+    public static NavigableSet<PeerStatistic> closePeers(final Number160 self, final Number160 other,
+                                                         final int atLeast,
+                                                         List<Map<Number160, PeerStatistic>> peerMap,
+                                                         Comparator<PeerStatistic> comparator) {
+
+        if (comparator == null) comparator = createXORStatisticComparator(other);
+        final NavigableSet<PeerStatistic> set = new TreeSet<PeerStatistic>(comparator);
         final int classMember = classMember(self, other);
         // special treatment, as we can start iterating from 0
         if (classMember == -1) {
@@ -539,8 +591,8 @@ public class PeerMap implements PeerStatusListener, Maintainable {
      * 
      * @return The XOR comparator
      */
-    public Comparator<PeerAddress> createComparator() {
-        return createComparator(self);
+    public Comparator<PeerAddress> createXORAddressComparator() {
+        return createXORAddressComparator(self);
     }
 
     /**
@@ -552,8 +604,8 @@ public class PeerMap implements PeerStatusListener, Maintainable {
         List<PeerAddress> all = new ArrayList<PeerAddress>();
         for (Map<Number160, PeerStatistic> map : peerMapVerified) {
             synchronized (map) {
-                for (PeerStatistic peerStatatistic : map.values()) {
-                    all.add(peerStatatistic.peerAddress());
+                for (PeerStatistic peerStatistic : map.values()) {
+                    all.add(peerStatistic.peerAddress());
                 }
             }
         }
@@ -577,8 +629,8 @@ public class PeerMap implements PeerStatusListener, Maintainable {
         List<PeerAddress> all = new ArrayList<PeerAddress>();
         for (Map<Number160, PeerStatistic> map : peerMapOverflow) {
             synchronized (map) {
-                for (PeerStatistic peerStatatistic : map.values()) {
-                    all.add(peerStatatistic.peerAddress());
+                for (PeerStatistic peerStatistic : map.values()) {
+                    all.add(peerStatistic.peerAddress());
                 }
             }
         }
@@ -654,17 +706,6 @@ public class PeerMap implements PeerStatusListener, Maintainable {
     }
 
     /**
-     * @see PeerMap.routing.Routing#isCloser(java.math.BigInteger, PeerAddress.routing.NodeAddress,
-     *      PeerAddress.routing.NodeAddress)
-     * @param key
-     *            The key to search for
-     * @param rn2
-     *            The remote node on the routing path to node close to key
-     * @param rn
-     *            An other remote node on the routing path to node close to key
-     * @return True if rn2 is closer or has the same distance to key as rn
-     */
-    /**
      * Returns -1 if the first remote node is closer to the key, if the secondBITS is closer, then 1 is returned. If
      * both are equal, 0 is returned
      * 
@@ -681,22 +722,73 @@ public class PeerMap implements PeerStatusListener, Maintainable {
     }
 
     /**
+     * Returns -1 if the first remote node is closer to the key, if the secondBITS is closer, then 1 is returned. If
+     * both are equal, 0 is returned
+     *
+     * @param ln The location
+     * @param rn The peer to test if closer to the id
+     * @param rn2 The other peer to test if closer to the id
+     * @return -1 if rn2 is closer to ln (in terms of xor distance bit length), 1 if
+     *          rn1 is closer or 0 if they are equal.
+     */
+    public static int classCloser(final Number160 ln, final PeerAddress rn, final PeerAddress rn2) {
+        Integer d1 = classMember(ln, rn.peerId());
+        Integer d2 = classMember(ln, rn2.peerId());
+        return d1.compareTo(d2);
+    }
+
+    /**
      * Create the Kademlia distance comparator.
      * 
-     * @param id
+     * @param location
      *            The id of this peer
      * @return The XOR comparator
      */
-    public static Comparator<PeerAddress> createComparator(final Number160 id) {
+    public static Comparator<PeerAddress> createXORAddressComparator(final Number160 location) {
         return new Comparator<PeerAddress>() {
             public int compare(final PeerAddress remotePeer, final PeerAddress remotePeer2) {
-                return isKadCloser(id, remotePeer, remotePeer2);
+                return isKadCloser(location, remotePeer, remotePeer2);
             }
         };
     }
+
+    public static Comparator<PeerStatistic> createXORStatisticComparator(final Number160 location) {
+        return new Comparator<PeerStatistic>() {
+            @Override
+            public int compare(PeerStatistic o1, PeerStatistic o2) {
+                if (o1.peerAddress() != null && o2.peerAddress() != null) {
+                    return isKadCloser(location, o1.peerAddress(), o2.peerAddress());
+                }
+                return 0;
+            }
+        };
+    }
+
+
+    public Comparator<PeerStatistic> createStatisticComparator(final Number160 location) {
+        return peerStatisticComparator.getComparator(location);
+    }
+
+    /**
+     * Takes a collection of PeerAddress and returns an equivalent collection
+     * of PeerStatistic from the PeerMap. New PeerStatistics are created for peers
+     * that are not yet in the PeerMap
+     * @param peerAddresses
+     * @return
+     */
+    public Collection<PeerStatistic> getPeerStatistics(Collection<PeerAddress> peerAddresses) {
+        HashSet<PeerStatistic> result = new HashSet<PeerStatistic>();
+        for (PeerAddress peerAddress : peerAddresses) {
+            PeerStatistic peerStatistic = getPeerStatistic(peerAddress);
+            if (peerStatistic == null) {
+                peerStatistic = new PeerStatistic(peerAddress);
+            }
+            result.add(peerStatistic);
+        }
+        return result;
+    }
     
-    public static Comparator<Number160> createComparator2(final Number160 id) {
-        return new Comparator<Number160>() {
+    public static Comparator<Number160> createComparator2(final Number160 id) { return new Comparator<Number160>() {
             public int compare(final Number160 remotePeer, final Number160 remotePeer2) {
                 return isCloser(id, remotePeer, remotePeer2);
             }
@@ -713,7 +805,7 @@ public class PeerMap implements PeerStatusListener, Maintainable {
      *            The second id
      * @return returns the bit difference and -1 if they are equal
      */
-    static int classMember(final Number160 id1, final Number160 id2) {
+    public static int classMember(final Number160 id1, final Number160 id2) {
         return distance(id1, id2).bitLength() - 1;
     }
 
@@ -745,9 +837,9 @@ public class PeerMap implements PeerStatusListener, Maintainable {
             final Map<Number160, PeerStatistic> tmp, final int maxFail) {
         if (tmp != null) {
             synchronized (tmp) {
-                PeerStatistic peerStatatistic = tmp.get(remotePeer.peerId());
-                if (peerStatatistic != null) {
-                    if (peerStatatistic.failed() >= maxFail) {
+                PeerStatistic peerStatistic = tmp.get(remotePeer.peerId());
+                if (peerStatistic != null) {
+                    if (peerStatistic.failed() >= maxFail) {
                         return true;
                     }
                 }
@@ -766,17 +858,20 @@ public class PeerMap implements PeerStatusListener, Maintainable {
      *            The address of the peer that may have been changed
      * @param firstHand
      *            True if this peer send and received a message from the remote peer
+     * @param roundTripTime
      * @return The old peer address if we have updated the peer, null otherwise
      */
     public static PeerStatistic updateExistingVerifiedPeerAddress(
-            final Map<Number160, PeerStatistic> tmp, final PeerAddress peerAddress, final boolean firstHand) {
+            final Map<Number160, PeerStatistic> tmp, final PeerAddress peerAddress, final boolean firstHand, RTT roundTripTime) {
         synchronized (tmp) {
             PeerStatistic old = tmp.get(peerAddress.peerId());
             if (old != null) {
             	//TODO: this should only be from firsthand!
                 old.peerAddress(peerAddress);
+                old.addRTT(roundTripTime);
                 if (firstHand) {
                     old.successfullyChecked();
+                    old.increaseNumberOfResponses();
                 }
                 return old;
             }
@@ -796,22 +891,22 @@ public class PeerMap implements PeerStatusListener, Maintainable {
      *            The bag where to take the addresses from
      * @return True if the desired size has been reached
      */
-    private static boolean fillSet(final int atLeast, final SortedSet<PeerAddress> set,
+    private static boolean fillSet(final int atLeast, final SortedSet<PeerStatistic> set,
             final Map<Number160, PeerStatistic> tmp) {
         synchronized (tmp) {
-            for (final PeerStatistic peerStatatistic : tmp.values()) {
-                set.add(peerStatatistic.peerAddress());
+            for (final PeerStatistic peerStatistic : tmp.values()) {
+                set.add(peerStatistic);
             }
         }
         return set.size() >= atLeast;
     }
 
-	public int bagSizeVerified() {
-	    return bagSizeVerified;
+	public int bagSizeVerified(int bag) {
+	    return bagSizesVerified[bag];
     }
 	
-	public int bagSizeOverflow() {
-	    return bagSizeOverflow;
+	public int bagSizeOverflow(int bag) {
+	    return bagSizesOverflow[bag];
     }
 
 	public PeerAddress find(Number160 peerId) {
@@ -820,9 +915,9 @@ public class PeerMap implements PeerStatusListener, Maintainable {
 			return null;
 		}
 		Map<Number160, PeerStatistic> tmp = peerMapVerified.get(classMember);
-		PeerStatistic peerStatatistic = tmp.get(peerId);
-		if(peerStatatistic!=null) {
-			return peerStatatistic.peerAddress();
+		PeerStatistic peerStatistic = tmp.get(peerId);
+		if(peerStatistic!=null) {
+			return peerStatistic.peerAddress();
 		}
 	    return null;
     }

--- a/core/src/main/java/net/tomp2p/peers/PeerStatistic.java
+++ b/core/src/main/java/net/tomp2p/peers/PeerStatistic.java
@@ -16,8 +16,11 @@
 package net.tomp2p.peers;
 
 import java.io.Serializable;
+import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+
+import net.tomp2p.utils.FIFOCache;
 
 /**
  * Keeps track of the statistics of a given peer.
@@ -26,10 +29,12 @@ import java.util.concurrent.atomic.AtomicLong;
  * 
  */
 public class PeerStatistic implements Serializable {
-    
-	private static final long serialVersionUID = -6225586345726672194L;
 
-	private final AtomicLong lastSeenOnline = new AtomicLong(0);
+    public static final int RTT_CACHE_SIZE = 5;
+
+    private static final long serialVersionUID = -6225586345726672194L;
+
+    private final AtomicLong lastSeenOnline = new AtomicLong(0);
 
     private final long created = System.currentTimeMillis();
 
@@ -42,6 +47,10 @@ public class PeerStatistic implements Serializable {
     private PeerAddress peerAddress;
     
     private boolean local;
+
+    private FIFOCache<RTT> rttCache = new FIFOCache<RTT>(RTT_CACHE_SIZE);
+
+    private long numberOfResponses = 0;
 
     /**
      * Constructor. Sets the peer address
@@ -106,6 +115,14 @@ public class PeerStatistic implements Serializable {
         return (int) (lastSeenOnline.get() - created);
     }
 
+    public long getNumberOfResponses() {
+        return numberOfResponses;
+    }
+
+    public void increaseNumberOfResponses() {
+        numberOfResponses++;
+    }
+
     /**
      * @return the peer address associated with this peer address
      */
@@ -129,28 +146,12 @@ public class PeerStatistic implements Serializable {
         return previousPeerAddress;
     }
     
-    @Override
-    public int hashCode() {
-        return peerId.hashCode();
-    }
-    
-    @Override
-    public boolean equals(Object obj) {
-        if(obj == this) {
-        	return true;
-        }
-        if(!(obj instanceof PeerStatistic)) {
-        	return false;
-        }
-        PeerStatistic p = (PeerStatistic) obj;
-        return p.peerId.equals(peerId);
-    }
-
 	public PeerStatistic local() {
 	    setLocal(true);
 		return this;
     }
-	
+
+
 	public boolean isLocal() {
 		return local;
     }
@@ -158,5 +159,98 @@ public class PeerStatistic implements Serializable {
 	public PeerStatistic setLocal(boolean local) {
 		this.local = local;
 		return this;
+    }
+
+    /**
+     * Adds a RTT to the cache. If the provided RTT object is an estimate
+     * it will be ignored in case there are already first-hand measurements
+     * in the cache. Also any real measurement will clear out any estimates
+     * in the cache beforehand. This prevents any mix-up between real
+     * measurements and estimates
+     *
+     * @param rtt   The RTT object that should be added
+     * @return      The PeerStatistic object
+     */
+    public PeerStatistic addRTT(RTT rtt) {
+        if (rtt != null && rtt.getRtt() > 0) {
+            // If we have estimates in the cache,
+            // clear cache before adding "real" measurement
+            if (containsEstimates()) {
+                if (!rtt.isEstimated())
+                    rttCache.clear();
+
+                rttCache.add(rtt);
+                return this;
+
+            // Only add measured RTTs to our cache if we have some already
+            // Estimates will be ignored after we received at least 1 "real" RTT
+            } else if (!rtt.isEstimated() || rttCache.isEmpty()) {
+                rttCache.add(rtt);
+                return this;
+            }
+        }
+        return this;
+    }
+
+    /**
+     * @return  True, if the RTT cache contains estimates, false if empty or
+     *          cache is empty.
+     */
+    public boolean containsEstimates() {
+        return !rttCache.isEmpty() && rttCache.peek().isEstimated();
+    }
+
+    /**
+     * @return Most recent RTT or null if cache is empty
+     */
+    public RTT getLatestRTT() {
+        if (rttCache.isEmpty())
+            return null;
+
+        return rttCache.peekTail();
+    }
+
+    /**
+     * Get the mean of the last 5 RTTs
+     *
+     * @return Average RTT in milliseconds or -1 if cache is empty.
+     */
+    public long getMeanRTT() {
+        if (rttCache.isEmpty())
+            return -1;
+
+        long sum = 0;
+        for (Iterator<RTT> iterator = rttCache.iterator(); iterator.hasNext(); ) {
+            RTT next = iterator.next();
+            sum += next.getRtt();
+        }
+        return sum / rttCache.size();
+    }
+
+    /**
+     * How many RTT measurements are in the cache
+     *
+     * @return  Number of RTT objects in cache. Number between
+     *          0 and RTT_CACHE_SIZE
+     */
+    public int getRTTCount() {
+        return rttCache.size();
+    }
+
+    @Override
+    public int hashCode() {
+        return peerId.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj == this) {
+            return true;
+        }
+        if(!(obj instanceof PeerStatistic)) {
+            return false;
+        }
+        PeerStatistic p = (PeerStatistic) obj;
+        return p.peerId.equals(peerId);
     }
 }

--- a/core/src/main/java/net/tomp2p/peers/PeerStatusListener.java
+++ b/core/src/main/java/net/tomp2p/peers/PeerStatusListener.java
@@ -51,5 +51,5 @@ public interface PeerStatusListener {
      * @param peerConnection 
      * @return False if nothing happened, true if there was a change
      */
-    boolean peerFound(final PeerAddress remotePeer, final PeerAddress referrer, PeerConnection peerConnection);
+    boolean peerFound(final PeerAddress remotePeer, final PeerAddress referrer, PeerConnection peerConnection, RTT roundTripTime);
 }

--- a/core/src/main/java/net/tomp2p/peers/RTT.java
+++ b/core/src/main/java/net/tomp2p/peers/RTT.java
@@ -1,0 +1,128 @@
+package net.tomp2p.peers;
+
+/**
+ * Class responsible for measuring and storing a Round Trip Time (RTT)
+ * This is used to compare peers with similar distance when routing.
+ *
+ * @author Sebastian Stephan
+ */
+public class RTT {
+    private long startMeasurementTimestamp = -1;
+    private long rtt = -1;
+    private boolean isUDP = true;
+    private boolean isEstimated = false;
+
+    // How much longer is TCP RTT compared to UDP
+    // Since TCP connections use 3-way handshake and an
+    // ACK to confirm, we assume a total of 4 transmissions
+    // for TCP, which is factor 2 longer than an UDP exchange
+    // TODO: Confirm with Wireshark
+    private static final double TCP_SCALE_DOWN_FACTOR = 3.5;
+
+    // Constructors
+    public RTT() {
+
+    }
+
+    /**
+     * Create RTT object with some given RTT, and a flag
+     * if the time was measured on a UDP exchange.
+     *
+     * @param rtt       The rtt to be set in milliseconds
+     * @param isUDP     True if this was an UDP exchange, set false
+     *                  if it was a TCP exchange.
+     */
+    public RTT(long rtt, boolean isUDP) {
+        this.rtt = rtt;
+        this.startMeasurementTimestamp = System.currentTimeMillis();
+        this.isUDP = isUDP;
+    }
+
+    /**
+     * Begin counting the time. Can be called multiple times,
+     * as long as it has not yet been stopped
+     *
+     * @return True if time measurement has been started, False otherwise
+     */
+    public boolean beginTimeMeasurement(boolean isUDP) {
+        if (getRtt() == -1) {
+            synchronized (this) {
+                this.startMeasurementTimestamp = System.currentTimeMillis();
+                this.isUDP = isUDP;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Stop the time measurement and calculate the rtt
+     * BeginTimeMeasurement must have been called before
+     * Can only be called once
+     *
+     * @return True if RTT was set, False otherwise
+     */
+    public boolean stopTimeMeasurement() {
+        synchronized (this) {
+            if (getRtt() == -1 && getStartMeasurementTimestamp() > 0) {
+                rtt = System.currentTimeMillis() - getStartMeasurementTimestamp();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public long getStartMeasurementTimestamp() {
+        return startMeasurementTimestamp;
+    }
+
+    /**
+     * Get round-trip-time in milliseconds. If the RTT was calculated
+     * by TCP, the value will be scaled down by TCP_SCALE_DOWN_FACTOR
+     *
+     * @return round-trip-time in milliseconds, -1 if no measurement done.
+     */
+    public long getRtt() {
+        if (isUDP)
+            return rtt;
+        else
+            return (int)(rtt / TCP_SCALE_DOWN_FACTOR);
+    }
+
+    public boolean isUDP() {
+        return isUDP;
+    }
+
+    /**
+     * Returns if the RTT measured is an estimate for some other peer
+     *
+     * @return True if it is an estimate, false otherwise
+     */
+    public boolean isEstimated() {
+        return isEstimated;
+    }
+
+    /**
+     * Marks this RTT object as an estimate
+     *
+     * @return The RTT object
+     */
+    public RTT setEstimated() {
+        isEstimated = true;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (isUDP)
+            sb.append("(UDP ");
+        else
+            sb.append(("TCP "));
+
+        sb.append(getRtt());
+        sb.append(")");
+
+        return sb.toString();
+    }
+}

--- a/core/src/main/java/net/tomp2p/rpc/DispatchHandler.java
+++ b/core/src/main/java/net/tomp2p/rpc/DispatchHandler.java
@@ -158,7 +158,7 @@ public abstract class DispatchHandler {
         // if we can contact the peer with its address. The peer may be
         // behind a NAT
     	if(requestMessage.command() != RPC.Commands.LOCAL_ANNOUNCE.getNr()) {
-    		peerBean.notifyPeerFound(requestMessage.sender(), requestMessage.sender(), peerConnection);
+    		peerBean.notifyPeerFound(requestMessage.sender(), requestMessage.sender(), peerConnection, null);
     	}
         
         try {

--- a/core/src/main/java/net/tomp2p/utils/FIFOCache.java
+++ b/core/src/main/java/net/tomp2p/utils/FIFOCache.java
@@ -1,0 +1,52 @@
+package net.tomp2p.utils;
+
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * A thread-safe FIFO Cache with a fixed size based on a ConcurrentLinkedQueue
+ *
+ * Replace with ConcurrentLinkedDeque when Java 1.7 is available on Android.
+ *
+ * Created by Sebastian Stephan on 03.12.14.
+ */
+public class FIFOCache<E> extends ConcurrentLinkedQueue<E> {
+    private final int max_size;
+
+    public FIFOCache(int max_size) {
+        this.max_size = max_size;
+    }
+
+    /**
+     * Add an element to the FIFO cache. If the cache is already full, the
+     * oldest element in the cache is removed.
+     *
+     * @param e Element to add
+     * @return True if the cache changed because of the insert
+     */
+    @Override
+    public boolean add(E e) {
+        if (!super.add(e))
+            return false;
+
+        while(super.size() > max_size)
+        {
+            poll();
+        }
+        return true;
+    }
+
+    /**
+     * Returns the tail element of the queue, i.e. the last inserted element
+     *
+     * @return The tail element or null if the list is empty
+     */
+    public E peekTail() {
+        Iterator<E> it = iterator();
+        E item = null;
+        while (it.hasNext())
+            item = it.next();
+
+        return item;
+    }
+}

--- a/core/src/test/java/net/tomp2p/Utils2.java
+++ b/core/src/test/java/net/tomp2p/Utils2.java
@@ -41,6 +41,7 @@ import net.tomp2p.peers.PeerAddress;
 import net.tomp2p.peers.PeerMap;
 import net.tomp2p.peers.PeerMapConfiguration;
 import net.tomp2p.peers.PeerSocketAddress;
+import net.tomp2p.peers.PeerStatistic;
 
 public class Utils2 {
     /**
@@ -105,6 +106,10 @@ public class Utils2 {
         return n1;
     }
 
+    public static PeerStatistic createStatistic(int id) throws UnknownHostException {
+        return new PeerStatistic(createAddress(new Number160(id), "127.0.0.1", 8005, 8006, false, false));
+    }
+
     public static Peer[] createNodes(int nrOfPeers, Random rnd, int port) throws Exception {
         return createNodes(nrOfPeers, rnd, port, null);
     }
@@ -133,7 +138,7 @@ public class Utils2 {
         if (nrOfPeers < 1) {
             throw new IllegalArgumentException("Cannot create less than 1 peer");
         }
-        Bindings bindings = new Bindings().addInterface("lo");
+        Bindings bindings = new Bindings();
         Peer[] peers = new Peer[nrOfPeers];
         if (automaticFuture != null) {
         	Number160 peerId = new Number160(rnd);
@@ -205,7 +210,7 @@ public class Utils2 {
     public static void perfectRouting(Peer... peers) {
         for (int i = 0; i < peers.length; i++) {
             for (int j = 0; j < peers.length; j++)
-                peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), null, null);
+                peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), null, null, null);
         }
         System.err.println("perfect routing done.");
     }
@@ -213,7 +218,7 @@ public class Utils2 {
     public static void perfectRoutingIndirect(Peer... peers) {
         for (int i = 0; i < peers.length; i++) {
             for (int j = 0; j < peers.length; j++)
-                peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), peers[j].peerAddress(), null);
+                peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), peers[j].peerAddress(), null, null);
         }
         System.err.println("perfect routing done.");
     }
@@ -274,8 +279,8 @@ public class Utils2 {
 
     public static void routing(Number160 key, Peer[] peers, int start) {
         System.out.println("routing: searching for key " + key);
-        NavigableSet<PeerAddress> pa1 = new TreeSet<PeerAddress>(PeerMap.createComparator(key));
-        NavigableSet<PeerAddress> queried = new TreeSet<PeerAddress>(PeerMap.createComparator(key));
+        NavigableSet<PeerAddress> pa1 = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(key));
+        NavigableSet<PeerAddress> queried = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(key));
         Number160 result = Number160.ZERO;
         Number160 resultPeer = new Number160("0xd75d1a3d57841fbc9e2a3d175d6a35dc2e15b9f");
         int round = 0;

--- a/core/src/test/java/net/tomp2p/message/TestMessage.java
+++ b/core/src/test/java/net/tomp2p/message/TestMessage.java
@@ -50,6 +50,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.cedarsoftware.util.DeepEquals;
 import net.tomp2p.Utils2;
 import net.tomp2p.connection.DSASignatureFactory;
 import net.tomp2p.message.Message.Content;
@@ -65,8 +66,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-
-import com.cedarsoftware.util.DeepEquals;
 
 /**
  * Tests encoding of an empty message. These tests should not be used for

--- a/core/src/test/java/net/tomp2p/p2p/TestBootstrap.java
+++ b/core/src/test/java/net/tomp2p/p2p/TestBootstrap.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Random;
 
 import net.tomp2p.Utils2;
-import net.tomp2p.futures.BaseFuture;
 import net.tomp2p.futures.FutureBootstrap;
 import net.tomp2p.futures.FutureDiscover;
 import net.tomp2p.peers.Number160;

--- a/core/src/test/java/net/tomp2p/p2p/TestConnection.java
+++ b/core/src/test/java/net/tomp2p/p2p/TestConnection.java
@@ -8,8 +8,11 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Random;
 
-import net.tomp2p.connection.*;
+import net.tomp2p.connection.Bindings;
+import net.tomp2p.connection.ChannelClientConfiguration;
 import net.tomp2p.connection.ChannelServerConfiguration;
+import net.tomp2p.connection.PipelineFilter;
+import net.tomp2p.connection.StandardProtocolFamily;
 import net.tomp2p.futures.FutureBootstrap;
 import net.tomp2p.futures.FutureDirect;
 import net.tomp2p.futures.FuturePeerConnection;

--- a/core/src/test/java/net/tomp2p/p2p/TestDirect.java
+++ b/core/src/test/java/net/tomp2p/p2p/TestDirect.java
@@ -1,7 +1,6 @@
 package net.tomp2p.p2p;
 
 
-
 import net.tomp2p.connection.Bindings;
 import net.tomp2p.futures.FutureDirect;
 import net.tomp2p.peers.Number160;

--- a/core/src/test/java/net/tomp2p/p2p/TestMaintenance.java
+++ b/core/src/test/java/net/tomp2p/p2p/TestMaintenance.java
@@ -20,10 +20,10 @@ public class TestMaintenance {
             Peer[] peers = Utils2.createRealNodes(10, rnd, 4001, new Rep(counter));
             master = peers[0];
             //give the master one of the peers,
-            master.peerBean().peerMap().peerFound(peers[1].peerAddress(), peers[2].peerAddress(), null);
+            master.peerBean().peerMap().peerFound(peers[1].peerAddress(), peers[2].peerAddress(), null, null);
             // wait for 1 sec.
             
-            master.peerBean().peerMap().peerFound(peers[1].peerAddress(), peers[2].peerAddress(), null);
+            master.peerBean().peerMap().peerFound(peers[1].peerAddress(), peers[2].peerAddress(), null, null);
             Thread.sleep(3000);
             
             //both peers pinged each other

--- a/core/src/test/java/net/tomp2p/p2p/TestRTTRoutingComparator.java
+++ b/core/src/test/java/net/tomp2p/p2p/TestRTTRoutingComparator.java
@@ -1,0 +1,96 @@
+package net.tomp2p.p2p;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Iterator;
+
+import net.tomp2p.peers.Number160;
+import net.tomp2p.peers.PeerAddress;
+import net.tomp2p.peers.PeerMap;
+import net.tomp2p.peers.PeerStatistic;
+import net.tomp2p.peers.RTT;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestRTTRoutingComparator {
+
+    /**
+     * Two PeerStatistic with the same PeerIDs should compare to 0 (equality)
+     */
+    @Test
+    public void testEquality() {
+        PeerAddress peer1 = new PeerAddress(new Number160("0xa3fb3982c38193f12c40a3fb3982c38193f12c60"));
+        PeerStatistic peer1Statistic = new PeerStatistic(peer1).addRTT(new RTT(13, false).setEstimated());
+        PeerAddress peer2 = new PeerAddress(new Number160("0xa3fb3982c38193f12c40a3fb3982c38193f12c60"));
+        PeerStatistic peer2Statistic = new PeerStatistic(peer2).addRTT(new RTT(44, true));
+
+        Comparator<PeerStatistic> comp = new RTTPeerStatisticComparator().getComparator(new Number160("0xfff"));
+
+        int compare = comp.compare(peer1Statistic,peer2Statistic);
+
+        Assert.assertEquals(compare, 0);
+    }
+
+    /**
+     * Two PeerStatistic with the same metrics but different PeerIDs should not compare to 0.
+     */
+    @Test
+    public void testUnequality() {
+        PeerAddress peer1 = new PeerAddress(new Number160("0xa3fb3982c38193f12c40a3fb3982c38193f12c61"));
+        PeerStatistic peer1Statistic = new PeerStatistic(peer1).addRTT(new RTT(44, true));
+        PeerAddress peer2 = new PeerAddress(new Number160("0xa3fb3982c38193f12c40a3fb3982c38193f12c62"));
+        PeerStatistic peer2Statistic = new PeerStatistic(peer2).addRTT(new RTT(44, true));
+
+        Comparator<PeerStatistic> comp = new RTTPeerStatisticComparator().getComparator(new Number160("0xfff"));
+
+        int compare = comp.compare(peer1Statistic,peer2Statistic);
+
+        Assert.assertNotEquals(compare, 0);
+    }
+
+    /**
+     * A queue with the comparator should result in the correct order when polling
+     */
+    @Test
+    public void testQueueToAskOrder() {
+        // Target location
+        Number160 location =                new Number160("0xa3fb3982c38193f12c40a3fb3982c38193f12c40");
+
+        // 4 Peers with different (bucket)distances to location
+        PeerAddress peer1 = new PeerAddress(new Number160("0xa3fb3982c38193f12c40a3fb3982c38193f12c60"));
+        PeerAddress peer2 = new PeerAddress(new Number160("0xa3fb3982c38193f12c40a3fb3982000000000000"));
+        PeerAddress peer3 = new PeerAddress(new Number160("0xa3fb3982c38193f12c40a3fb3982700000000000"));
+        PeerAddress peer4 = new PeerAddress(new Number160("0xa3fb3982c38193f12c40a3fb3982c38193f12c70"));
+
+        // Test all bucket distances to location (this will be the first sorting criteria)
+        Assert.assertEquals(6, PeerMap.classMember(peer1.peerId(), location) + 1);
+        Assert.assertEquals(48, PeerMap.classMember(peer2.peerId(), location) + 1);
+        Assert.assertEquals(48, PeerMap.classMember(peer3.peerId(), location) + 1);
+        Assert.assertEquals(6, PeerMap.classMember(peer4.peerId(), location) + 1);
+
+        // Define Peer Statistics with some RTTs
+        PeerStatistic stat1 = new PeerStatistic(peer1).addRTT(new RTT(80, true));
+        PeerStatistic stat2 = new PeerStatistic(peer2).addRTT(new RTT(30, true));
+        PeerStatistic stat3 = new PeerStatistic(peer3).addRTT(new RTT(5, true)) .addRTT(new RTT(45, true));
+        PeerStatistic stat4 = new PeerStatistic(peer4); // no rtt available
+
+        // Create routing queue with comparator and add all statistics
+        UpdatableTreeSet<PeerStatistic> queueToAsk = new UpdatableTreeSet<PeerStatistic>(new RTTPeerStatisticComparator().getComparator(location));
+        queueToAsk.addAll(Arrays.asList(stat1,stat2,stat3,stat4));
+
+        // Sorting should be in the following priority order
+        // 1. KAD bucket distance (how many high-order bits are equal to destination)
+        //        (Note that this is different from the complete XOR distance)
+        // 2. RTT information available: Those with RTT come before those without RTT
+        // 3. RTT Faster peers (low RTT) before slow peers (high RTT)
+        // 4. Complete XOR Distance
+        Iterator<PeerStatistic> it = queueToAsk.iterator();
+        Assert.assertEquals(queueToAsk.pollFirst().peerAddress(), peer1); // Dist 6, 80 RTT
+        Assert.assertEquals(queueToAsk.pollFirst().peerAddress(), peer4); // Dist 6, no RTT info
+        Assert.assertEquals(queueToAsk.pollFirst().peerAddress(), peer3); // Dist 48 25 RTT
+        Assert.assertEquals(queueToAsk.pollFirst().peerAddress(), peer2); // Dist 48 30ms RTT
+    }
+
+
+}

--- a/core/src/test/java/net/tomp2p/p2p/TestRouting.java
+++ b/core/src/test/java/net/tomp2p/p2p/TestRouting.java
@@ -20,6 +20,7 @@ import net.tomp2p.p2p.builder.RoutingBuilder;
 import net.tomp2p.peers.Number160;
 import net.tomp2p.peers.PeerAddress;
 import net.tomp2p.peers.PeerMap;
+import net.tomp2p.peers.PeerStatistic;
 import net.tomp2p.utils.Pair;
 import net.tomp2p.utils.Utils;
 
@@ -36,26 +37,26 @@ public class TestRouting {
     @Test
     public void testMerge() throws UnknownHostException {
         // setup
-        SortedSet<PeerAddress> queue = new TreeSet<PeerAddress>(PeerMap.createComparator(new Number160(88)));
-        SortedSet<PeerAddress> neighbors = new TreeSet<PeerAddress>(
-                PeerMap.createComparator(new Number160(88)));
-        SortedSet<PeerAddress> already = new TreeSet<PeerAddress>(PeerMap.createComparator(new Number160(88)));
-        queue.add(Utils2.createAddress(12));
-        queue.add(Utils2.createAddress(14));
-        queue.add(Utils2.createAddress(16));
-        neighbors.add(Utils2.createAddress(88));
-        neighbors.add(Utils2.createAddress(12));
-        neighbors.add(Utils2.createAddress(16));
+        UpdatableTreeSet<PeerStatistic> queue = new UpdatableTreeSet<PeerStatistic>(PeerMap.createXORStatisticComparator(new Number160(88)));
+        SortedSet<PeerStatistic> neighbors = new TreeSet<PeerStatistic>(
+                PeerMap.createXORStatisticComparator(new Number160(88)));
+        SortedSet<PeerAddress> already = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(new Number160(88)));
+        queue.add(Utils2.createStatistic(12));
+        queue.add(Utils2.createStatistic(14));
+        queue.add(Utils2.createStatistic(16));
+        neighbors.add(Utils2.createStatistic(88));
+        neighbors.add(Utils2.createStatistic(12));
+        neighbors.add(Utils2.createStatistic(16));
         // do testing and verification
         already.add(Utils2.createAddress(16));
-        boolean testb = RoutingMechanism.merge(queue, neighbors, already);
+        boolean testb = RoutingMechanism.merge(queue,neighbors,already);
         Assert.assertEquals(true, testb);
         // next one
-        neighbors.add(Utils2.createAddress(89));
+        neighbors.add(Utils2.createStatistic(89));
         testb = RoutingMechanism.merge(queue, neighbors, already);
         Assert.assertEquals(false, testb);
         // next one
-        neighbors.add(Utils2.createAddress(88));
+        neighbors.add(Utils2.createStatistic(88));
         testb = RoutingMechanism.merge(queue, neighbors, already);
         Assert.assertEquals(false, testb);
     }
@@ -63,16 +64,16 @@ public class TestRouting {
     @Test
     public void testEvaluate() throws UnknownHostException {
         // setup
-        SortedSet<PeerAddress> queue = new TreeSet<PeerAddress>(PeerMap.createComparator(new Number160(88)));
-        SortedSet<PeerAddress> neighbors = new TreeSet<PeerAddress>(
-                PeerMap.createComparator(new Number160(88)));
-        SortedSet<PeerAddress> already = new TreeSet<PeerAddress>(PeerMap.createComparator(new Number160(88)));
-        queue.add(Utils2.createAddress(12));
-        queue.add(Utils2.createAddress(14));
-        queue.add(Utils2.createAddress(16));
-        neighbors.add(Utils2.createAddress(89));
-        neighbors.add(Utils2.createAddress(12));
-        neighbors.add(Utils2.createAddress(16));
+        UpdatableTreeSet<PeerStatistic> queue = new UpdatableTreeSet<PeerStatistic>(PeerMap.createXORStatisticComparator(new Number160(88)));
+        SortedSet<PeerStatistic> neighbors = new TreeSet<PeerStatistic>(
+                PeerMap.createXORStatisticComparator(new Number160(88)));
+        SortedSet<PeerAddress> already = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(new Number160(88)));
+        queue.add(Utils2.createStatistic(12));
+        queue.add(Utils2.createStatistic(14));
+        queue.add(Utils2.createStatistic(16));
+        neighbors.add(Utils2.createStatistic(89));
+        neighbors.add(Utils2.createStatistic(12));
+        neighbors.add(Utils2.createStatistic(16));
         already.add(Utils2.createAddress(16));
         RoutingMechanism routingMechanism = new RoutingMechanism(null, null, null);
         // do testing and verification
@@ -83,21 +84,21 @@ public class TestRouting {
         testb = routingMechanism.evaluateInformation(neighbors, queue, already, 2);
         Assert.assertEquals(1, routingMechanism.nrNoNewInfo());
         Assert.assertEquals(false, testb);
-        neighbors.add(Utils2.createAddress(11));
+        neighbors.add(Utils2.createStatistic(11));
         testb = routingMechanism.evaluateInformation(neighbors, queue, already, 2);
         Assert.assertEquals(2, routingMechanism.nrNoNewInfo());
         Assert.assertEquals(true, testb);
-        neighbors.add(Utils2.createAddress(88));
+        neighbors.add(Utils2.createStatistic(88));
         testb = routingMechanism.evaluateInformation(neighbors, queue, already, 2);
         Assert.assertEquals(0, routingMechanism.nrNoNewInfo());
         Assert.assertEquals(false, testb);
         //
         testb = routingMechanism.evaluateInformation(neighbors, queue, already, 2);
         Assert.assertEquals(1, routingMechanism.nrNoNewInfo());
-        neighbors.add(Utils2.createAddress(89));
+        neighbors.add(Utils2.createStatistic(89));
         testb = routingMechanism.evaluateInformation(neighbors, queue, already, 2);
         Assert.assertEquals(2, routingMechanism.nrNoNewInfo());
-        neighbors.add(Utils2.createAddress(88));
+        neighbors.add(Utils2.createStatistic(88));
         testb = routingMechanism.evaluateInformation(neighbors, queue, already, 2);
         Assert.assertEquals(3, routingMechanism.nrNoNewInfo());
         Assert.assertEquals(true, testb);
@@ -458,13 +459,13 @@ public class TestRouting {
      * @param peers
      *            The peers that will be added
      */
-    private void addToPeerMap(Peer peer, PeerAddress... peers) {
+    public static void addToPeerMap(Peer peer, PeerAddress... peers) {
         for (int i = 0; i < peers.length; i++) {
-            peer.peerBean().peerMap().peerFound(peers[i], null, null);
+            peer.peerBean().peerMap().peerFound(peers[i], null, null, null);
         }
     }
 
-    private Peer[] createSpecialPeers(int nr) throws Exception {
+    public static Peer[] createSpecialPeers(int nr) throws Exception {
         StringBuilder sb = new StringBuilder("0x");
         Peer[] peers = new Peer[nr];
         for (int i = 0; i < nr; i++) {
@@ -485,10 +486,10 @@ public class TestRouting {
             master = peers[0];
             Utils2.perfectRouting(peers);
             // do testing
-            Collection<PeerAddress> pas = peers[30].peerBean().peerMap()
+            Collection<PeerStatistic> pas = peers[30].peerBean().peerMap()
                     .closePeers(peers[30].peerID(), 20);
-            Iterator<PeerAddress> i = pas.iterator();
-            PeerAddress p1 = i.next();
+            Iterator<PeerStatistic> i = pas.iterator();
+            PeerAddress p1 = i.next().peerAddress();
             Assert.assertEquals(peers[262].peerAddress(), p1);
         } finally {
             master.shutdown().await();
@@ -705,7 +706,7 @@ public class TestRouting {
                 Peer[] peers = Utils2.createNodes(200, rnd, 4001);
                 master = peers[0];
                 Utils2.perfectRouting(peers);
-                Comparator<PeerAddress> cmp = PeerMap.createComparator(find);
+                Comparator<PeerAddress> cmp = PeerMap.createXORAddressComparator(find);
                 SortedSet<PeerAddress> ss = new TreeSet<PeerAddress>(cmp);
                 for (int i = 0; i < peers.length; i++) {
                     ss.add(peers[i].peerAddress());
@@ -757,4 +758,31 @@ public class TestRouting {
             }
         }
     }
+
+    private void printPeerMaps(Peer... peers) {
+        for (Peer peer : peers) {
+            System.out.println(peer.peerAddress().peerId().toString(true) + ":");
+            System.out.println("\tVerified:");
+            for (int bucket=0; bucket<160; bucket++) {
+                if (!peer.peerBean().peerMap().peerMapVerified().get(bucket).isEmpty()) {
+                    System.out.print("\t\tBucket " + bucket + ":");
+                    for (PeerStatistic ps : peer.peerBean().peerMap().peerMapVerified().get(bucket).values()) {
+                        System.out.print(" " + ps.peerAddress().peerId().toString(true));
+                    }
+                    System.out.print("\n");
+                }
+            }
+            System.out.println("\tOverflow:");
+            for (int bucket=0; bucket<160; bucket++) {
+                if (!peer.peerBean().peerMap().peerMapOverflow().get(bucket).isEmpty()) {
+                    System.out.print("\t\tBucket " + bucket + ":");
+                    for (PeerStatistic ps : peer.peerBean().peerMap().peerMapOverflow().get(bucket).values()) {
+                        System.out.print(" " + ps.peerAddress().peerId().toString(true));
+                    }
+                    System.out.print("\n");
+                }
+            }
+        }
+    }
+
 }

--- a/core/src/test/java/net/tomp2p/p2p/TestStatistics.java
+++ b/core/src/test/java/net/tomp2p/p2p/TestStatistics.java
@@ -40,7 +40,7 @@ public class TestStatistics {
 		for (int j = 1; j < 20; j++) {
 			int nr = 100000 * j;
 			PeerMapConfiguration conf = new PeerMapConfiguration(ID);
-			conf.bagSizeVerified(20).bagSizeOverflow(20);
+			conf.setFixedVerifiedBagSizes(20).setFixedOverflowBagSizes(20);
 			conf.offlineCount(1000).offlineTimeout(60);
 			conf.addPeerFilter(new DefaultPeerFilter()).maintenance(new DefaultMaintenance(0, new int[] {}));
 			PeerMap peerMap = new PeerMap(conf);
@@ -48,7 +48,7 @@ public class TestStatistics {
 			Statistics statistics = new Statistics(peerMap);
 			for (int i = 0; i < nr; i++) {
 				PeerAddress pa = Utils2.createAddress(new Number160(rnd));
-				peerMap.peerFound(pa, null, null);
+				peerMap.peerFound(pa, null, null, null);
 			}
 
 			double diff = nr / statistics.estimatedNumberOfNodes();

--- a/core/src/test/java/net/tomp2p/peers/TestPeerMap.java
+++ b/core/src/test/java/net/tomp2p/peers/TestPeerMap.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 public class TestPeerMap {
 
     private static final Number160 ID = new Number160("0x1");
-    
+
     @Test
     public void testDifference() throws UnknownHostException {
         // setup
@@ -49,8 +49,8 @@ public class TestPeerMap {
         newC.add(Utils2.createAddress(88));
         newC.add(Utils2.createAddress(90));
         newC.add(Utils2.createAddress(91));
-        SortedSet<PeerAddress> result = new TreeSet<PeerAddress>(PeerMap.createComparator(new Number160(88)));
-        SortedSet<PeerAddress> already = new TreeSet<PeerAddress>(PeerMap.createComparator(new Number160(88)));
+        SortedSet<PeerAddress> result = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(new Number160(88)));
+        SortedSet<PeerAddress> already = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(new Number160(88)));
         already.add(Utils2.createAddress(90));
         already.add(Utils2.createAddress(15));
         // do testing
@@ -63,7 +63,7 @@ public class TestPeerMap {
     @Test
     public void testAdd1() {
         PeerMapConfiguration conf = new PeerMapConfiguration(ID);
-        conf.bagSizeVerified(4).bagSizeOverflow(4);
+        conf.setFixedVerifiedBagSizes(4).setFixedOverflowBagSizes(4);
         conf.offlineCount(1000).offlineTimeout(60);
         conf.addPeerFilter(new DefaultPeerFilter()).maintenance(new DefaultMaintenance(0, new int[] {}));
         PeerMap peerMap = new PeerMap(conf);
@@ -90,30 +90,30 @@ public class TestPeerMap {
         PeerAddress pa4 = new PeerAddress(id4);
         PeerAddress pa5 = new PeerAddress(id5);
         PeerAddress pa6 = new PeerAddress(id6);
-        peerMap.peerFound(pa1, null, null);
-        peerMap.peerFound(pa2, null, null);
-        peerMap.peerFound(pa3, null, null);
-        peerMap.peerFound(pa4, null, null);
-        peerMap.peerFound(pa5, null, null);
-        peerMap.peerFound(pa6, null, null);
-        SortedSet<PeerAddress> pa = peerMap.closePeers(ID, 2);
+        peerMap.peerFound(pa1, null, null, null);
+        peerMap.peerFound(pa2, null, null, null);
+        peerMap.peerFound(pa3, null, null, null);
+        peerMap.peerFound(pa4, null, null, null);
+        peerMap.peerFound(pa5, null, null, null);
+        peerMap.peerFound(pa6, null, null, null);
+        SortedSet<PeerStatistic> pa = peerMap.closePeers(ID, 2);
         Assert.assertEquals(2, pa.size());
-        Iterator<PeerAddress> iterator = pa.iterator();
-        Assert.assertEquals("0x3", iterator.next().peerId().toString());
-        Assert.assertEquals("0x2", iterator.next().peerId().toString());
+        Iterator<PeerStatistic> iterator = pa.iterator();
+        Assert.assertEquals("0x3", iterator.next().peerAddress().peerId().toString());
+        Assert.assertEquals("0x2", iterator.next().peerAddress().peerId().toString());
         pa = peerMap.closePeers(id3, 3);
         Assert.assertEquals(4, pa.size());
         iterator = pa.iterator();
-        Assert.assertEquals("0x4", iterator.next().peerId().toString());
-        Assert.assertEquals("0x5", iterator.next().peerId().toString());
-        Assert.assertEquals("0x6", iterator.next().peerId().toString());
-        Assert.assertEquals("0x7", iterator.next().peerId().toString());
+        Assert.assertEquals("0x4", iterator.next().peerAddress().peerId().toString());
+        Assert.assertEquals("0x5", iterator.next().peerAddress().peerId().toString());
+        Assert.assertEquals("0x6", iterator.next().peerAddress().peerId().toString());
+        Assert.assertEquals("0x7", iterator.next().peerAddress().peerId().toString());
     }
 
     @Test
     public void testAdd2() {
         PeerMapConfiguration conf = new PeerMapConfiguration(ID);
-        conf.bagSizeVerified(3).bagSizeOverflow(3);
+        conf.setFixedVerifiedBagSizes(3).setFixedOverflowBagSizes(3);
         conf.offlineCount(1000).offlineTimeout(60);
         conf.addPeerFilter(new DefaultPeerFilter()).maintenance(new DefaultMaintenance(0, new int[] {}));
         PeerMap peerMap = new PeerMap(conf);
@@ -131,23 +131,23 @@ public class TestPeerMap {
         PeerAddress pa4 = new PeerAddress(id4);
         PeerAddress pa5 = new PeerAddress(id5);
         PeerAddress pa6 = new PeerAddress(id6);
-        peerMap.peerFound(pa1, null, null);
-        peerMap.peerFound(pa2, null, null);
-        peerMap.peerFound(pa3, null, null);
-        peerMap.peerFound(pa4, null, null);
-        peerMap.peerFound(pa5, null, null);
-        peerMap.peerFound(pa6, null, null);
-        SortedSet<PeerAddress> pa = peerMap.closePeers(ID, 2);
+        peerMap.peerFound(pa1, null, null, null);
+        peerMap.peerFound(pa2, null, null, null);
+        peerMap.peerFound(pa3, null, null, null);
+        peerMap.peerFound(pa4, null, null, null);
+        peerMap.peerFound(pa5, null, null, null);
+        peerMap.peerFound(pa6, null, null, null);
+        SortedSet<PeerStatistic> pa = peerMap.closePeers(ID, 2);
         Assert.assertEquals(2, pa.size());
-        Iterator<PeerAddress> iterator = pa.iterator();
-        Assert.assertEquals("0x3", iterator.next().peerId().toString());
-        Assert.assertEquals("0x2", iterator.next().peerId().toString());
+        Iterator<PeerStatistic> iterator = pa.iterator();
+        Assert.assertEquals("0x3", iterator.next().peerAddress().peerId().toString());
+        Assert.assertEquals("0x2", iterator.next().peerAddress().peerId().toString());
         pa = peerMap.closePeers(id3, 3);
         Assert.assertEquals(3, pa.size());
         iterator = pa.iterator();
-        Assert.assertEquals("0x4", iterator.next().peerId().toString());
-        Assert.assertEquals("0x5", iterator.next().peerId().toString());
-        Assert.assertEquals("0x6", iterator.next().peerId().toString());
+        Assert.assertEquals("0x4", iterator.next().peerAddress().peerId().toString());
+        Assert.assertEquals("0x5", iterator.next().peerAddress().peerId().toString());
+        Assert.assertEquals("0x6", iterator.next().peerAddress().peerId().toString());
         // 0x7 is in the non-verified / overflow map
         List<PeerAddress> list = peerMap.allOverflow();
         Assert.assertEquals("0x7", list.iterator().next().peerId().toString());
@@ -190,29 +190,29 @@ public class TestPeerMap {
         PeerAddress rn2 = new PeerAddress(new Number160(66));
         PeerAddress rn3 = new PeerAddress(new Number160(67));
         PeerMapConfiguration conf = new PeerMapConfiguration(ID);
-        conf.bagSizeVerified(3).bagSizeOverflow(3);
+        conf.setFixedVerifiedBagSizes(3).setFixedOverflowBagSizes(3);
         conf.offlineCount(1000).offlineTimeout(60);
         conf.addPeerFilter(new DefaultPeerFilter()).maintenance(new DefaultMaintenance(0, new int[] {}));
         PeerMap peerMap = new PeerMap(conf);
-        SortedSet<PeerAddress> rc = peerMap.closePeers(new Number160(98), 3);
-        rc.add(rn2);
-        rc.add(rn1);
-        rc.add(rn3);
-        Assert.assertTrue(rc.first().equals(rn1));
+        SortedSet<PeerStatistic> rc = peerMap.closePeers(new Number160(98), 3);
+        rc.add(new PeerStatistic(rn2));
+        rc.add(new PeerStatistic(rn1));
+        rc.add(new PeerStatistic(rn3));
+        Assert.assertTrue(rc.first().peerAddress().equals(rn1));
     }
 
     @Test
     public void testAddNode() throws UnknownHostException {
         PeerMapConfiguration conf = new PeerMapConfiguration(ID);
-        conf.bagSizeVerified(4).bagSizeOverflow(4);
+        conf.setFixedVerifiedBagSizes(4).setFixedOverflowBagSizes(4);
         conf.offlineCount(1000).offlineTimeout(60);
         conf.addPeerFilter(new DefaultPeerFilter()).maintenance(new DefaultMaintenance(0, new int[] {}));
         PeerMap peerMap = new PeerMap(conf);
         for (int i = 1; i < 12; i++) {
             PeerAddress r1 = new PeerAddress(new Number160(i));
-            peerMap.peerFound(r1, null, null);
+            peerMap.peerFound(r1, null, null, null);
         }
-        SortedSet<PeerAddress> close = peerMap.closePeers(new Number160(2), 2);
+        SortedSet<PeerStatistic> close = peerMap.closePeers(new Number160(2), 2);
         Assert.assertEquals(2, close.size());
         close = peerMap.closePeers(new Number160(6), 4);
         Assert.assertEquals(4, close.size());
@@ -221,15 +221,15 @@ public class TestPeerMap {
     @Test
     public void testAddNode2() throws UnknownHostException {
         PeerMapConfiguration conf = new PeerMapConfiguration(ID);
-        conf.bagSizeVerified(3).bagSizeOverflow(3);
+        conf.setFixedVerifiedBagSizes(3).setFixedOverflowBagSizes(3);
         conf.offlineCount(1000).offlineTimeout(60);
         conf.addPeerFilter(new DefaultPeerFilter()).maintenance(new DefaultMaintenance(0, new int[] {}));
         PeerMap peerMap = new PeerMap(conf);
         for (int i = 1; i < 12; i++) {
             PeerAddress r1 = new PeerAddress(new Number160((i % 6) + 1));
-            peerMap.peerFound(r1, null, null);
+            peerMap.peerFound(r1, null, null, null);
         }
-        SortedSet<PeerAddress> close = peerMap.closePeers(new Number160(2), 2);
+        SortedSet<PeerStatistic> close = peerMap.closePeers(new Number160(2), 2);
         Assert.assertEquals(2, close.size());
         close = peerMap.closePeers(new Number160(6), 1);
         Assert.assertEquals(3, close.size());
@@ -238,13 +238,13 @@ public class TestPeerMap {
     @Test
     public void testRemove() throws UnknownHostException, InterruptedException {
         PeerMapConfiguration conf = new PeerMapConfiguration(ID);
-        conf.bagSizeVerified(3).bagSizeOverflow(3);
+        conf.setFixedVerifiedBagSizes(3).setFixedOverflowBagSizes(3);
         conf.offlineCount(1000).offlineTimeout(1);
         conf.addPeerFilter(new DefaultPeerFilter()).maintenance(new DefaultMaintenance(0, new int[] {}));
         PeerMap peerMap = new PeerMap(conf);
         for (int i = 1; i <= 200; i++) {
             PeerAddress r1 = new PeerAddress(new Number160(i + 1));
-            peerMap.peerFound(r1, null, null);
+            peerMap.peerFound(r1, null, null, null);
         }
         Assert.assertEquals(20, peerMap.size());
         peerMap.peerFailed(new PeerAddress(new Number160(100)), new PeerException(AbortCause.PROBABLY_OFFLINE, "probably offline"));
@@ -262,13 +262,13 @@ public class TestPeerMap {
     @Test
     public void testRemoveConcurrent() throws UnknownHostException, InterruptedException {
         PeerMapConfiguration conf = new PeerMapConfiguration(ID);
-        conf.bagSizeVerified(3).bagSizeOverflow(3);
+        conf.setFixedVerifiedBagSizes(3).setFixedOverflowBagSizes(3);
         conf.offlineCount(1000).offlineTimeout(1);
         conf.addPeerFilter(new DefaultPeerFilter()).maintenance(new DefaultMaintenance(0, new int[] {}));
         final PeerMap peerMap = new PeerMap(conf);
         for (int i = 1; i <= 200; i++) {
             PeerAddress r1 = new PeerAddress(new Number160(i + 1));
-            peerMap.peerFound(r1, null, null);
+            peerMap.peerFound(r1, null, null, null);
         }
         Assert.assertEquals(20, peerMap.size());
         Thread t1 = new Thread(new Runnable() {
@@ -300,7 +300,7 @@ public class TestPeerMap {
     @Test
     public void testAddConcurrent() throws UnknownHostException, InterruptedException {
         PeerMapConfiguration conf = new PeerMapConfiguration(ID);
-        conf.bagSizeVerified(3).bagSizeOverflow(3);
+        conf.setFixedVerifiedBagSizes(3).setFixedOverflowBagSizes(3);
         conf.offlineCount(1000).offlineTimeout(1);
         conf.addPeerFilter(new DefaultPeerFilter()).maintenance(new DefaultMaintenance(0, new int[] {}));
         final PeerMap peerMap = new PeerMap(conf);
@@ -308,7 +308,7 @@ public class TestPeerMap {
             @Override
             public void run() {
                 for (int i = 1; i <= 50; i++) {
-                    peerMap.peerFound(new PeerAddress(new Number160(i + 1)), null, null);
+                    peerMap.peerFound(new PeerAddress(new Number160(i + 1)), null, null, null);
                 }
             }
         });
@@ -317,7 +317,7 @@ public class TestPeerMap {
             @Override
             public void run() {
                 for (int i = 1; i <= 100; i++) {
-                    peerMap.peerFound(new PeerAddress(new Number160(i + 1)), null, null);
+                    peerMap.peerFound(new PeerAddress(new Number160(i + 1)), null, null, null);
                 }
             }
         });
@@ -352,7 +352,7 @@ public class TestPeerMap {
     public void testRandomAddRemove() throws InterruptedException {
         for (int j = 0; j < 50; j++) {
             PeerMapConfiguration conf = new PeerMapConfiguration(ID);
-            conf.bagSizeVerified(j + 1).bagSizeOverflow(j + 1);
+            conf.setFixedVerifiedBagSizes(j + 1).setFixedOverflowBagSizes(j + 1);
             conf.offlineCount(1000).offlineTimeout(1);
             conf.addPeerFilter(new DefaultPeerFilter()).maintenance(new DefaultMaintenance(0, new int[] {}));
             final PeerMap peerMap = new PeerMap(conf);
@@ -367,7 +367,7 @@ public class TestPeerMap {
                 public void run() {
                     for (int i = 1; i <= rounds + diff; i++) {
                         if (i + diff < rounds) {
-                            boolean retVal = peerMap.peerFound(new PeerAddress(new Number160(i + 1)), null, null);
+                            boolean retVal = peerMap.peerFound(new PeerAddress(new Number160(i + 1)), null, null, null);
                             if (retVal) {
                                 add.incrementAndGet();
                             }
@@ -397,7 +397,7 @@ public class TestPeerMap {
     @Test
     public void testPerformance() throws IOException {
         PeerMapConfiguration conf = new PeerMapConfiguration(ID);
-        conf.bagSizeVerified(3).bagSizeOverflow(3);
+        conf.setFixedVerifiedBagSizes(3).setFixedOverflowBagSizes(3);
         conf.offlineCount(1000).offlineTimeout(100);
         conf.addPeerFilter(new DefaultPeerFilter()).maintenance(new DefaultMaintenance(0, new int[] {}));
         final PeerMap peerMap = new PeerMap(conf);
@@ -411,10 +411,10 @@ public class TestPeerMap {
             listAdded.add(r1);
         }
         for (PeerAddress r1 : listAdded) {
-            peerMap.peerFound(r1, null, null);
+            peerMap.peerFound(r1, null, null, null);
         }
         for (PeerAddress r1 : listAdded) {
-            peerMap.peerFound(r1, null, null);
+            peerMap.peerFound(r1, null, null, null);
         }
         for (int i = 0; i < 100; i++) {
             PeerAddress removed = listAdded.get(random.nextInt(i + 1));
@@ -423,7 +423,7 @@ public class TestPeerMap {
             }
         }
         for (PeerAddress r1 : listAdded) {
-            peerMap.peerFound(r1, r1, null);
+            peerMap.peerFound(r1, r1, null, null);
         }
         Assert.assertEquals(47, peerMap.size());
         for (PeerAddress r1 : listRemoved) {
@@ -454,7 +454,7 @@ public class TestPeerMap {
         PeerAddress n2 = new PeerAddress(b2);
         PeerAddress n3 = new PeerAddress(b3);
         PeerAddress n4 = new PeerAddress(b4);
-        final NavigableSet<PeerAddress> queue = new TreeSet<PeerAddress>(PeerMap.createComparator(b3));
+        final NavigableSet<PeerAddress> queue = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(b3));
         queue.add(n1);
         queue.add(n2);
         queue.add(n3);
@@ -467,7 +467,7 @@ public class TestPeerMap {
     @Test
     public void testMaintenance() throws UnknownHostException, InterruptedException {
         PeerMapConfiguration conf = new PeerMapConfiguration(ID);
-        conf.bagSizeVerified(10).bagSizeOverflow(10);
+        conf.setFixedVerifiedBagSizes(10).setFixedOverflowBagSizes(10);
         conf.offlineCount(1000).offlineTimeout(100);
         conf.addPeerFilter(new DefaultPeerFilter()).maintenance(new DefaultMaintenance(0, new int[] {}));
         
@@ -478,7 +478,7 @@ public class TestPeerMap {
         PeerAddress pa1 = Utils2.createAddress(Number160.createHash("peer 1"));
         PeerAddress pa2 = Utils2.createAddress(Number160.createHash("peer 2"));
         
-        peerMap.peerFound(pa2, pa1, null);
+        peerMap.peerFound(pa2, pa1, null, null);
         List<PeerAddress> notInterested = new ArrayList<PeerAddress>();
         PeerStatistic peerStatatistic = peerMap.nextForMaintenance(notInterested);
         notInterested.add(peerStatatistic.peerAddress());
@@ -487,7 +487,7 @@ public class TestPeerMap {
         Assert.assertEquals(true, peerStatatistic == null);
         
         PeerAddress pa3 = Utils2.createAddress(Number160.createHash("peer 3"));
-        peerMap.peerFound(pa3, null, null);
+        peerMap.peerFound(pa3, null, null, null);
         peerStatatistic = peerMap.nextForMaintenance(notInterested);
         Assert.assertEquals(true, peerStatatistic == null);
         Thread.sleep(1000);
@@ -508,7 +508,7 @@ public class TestPeerMap {
 
             Number160 key = new Number160(rnd);
             PeerMapConfiguration conf = new PeerMapConfiguration(ID);
-            conf.bagSizeVerified(10).bagSizeOverflow(10);
+            conf.setFixedVerifiedBagSizes(10).setFixedOverflowBagSizes(10);
             conf.offlineCount(1000).offlineTimeout(100);
             conf.addPeerFilter(new DefaultPeerFilter()).maintenance(new DefaultMaintenance(0, new int[] {}));
             final PeerMap peerMap = new PeerMap(conf);
@@ -516,13 +516,13 @@ public class TestPeerMap {
             for (int i = 0; i < round; i++) {
                 PeerAddress r1 = new PeerAddress(new Number160(rnd));
                 peers.add(r1);
-                peerMap.peerFound(r1, null, null);
+                peerMap.peerFound(r1, null, null, null);
             }
 
-            TreeSet<PeerAddress> set = new TreeSet<PeerAddress>(PeerMap.createComparator(key));
+            TreeSet<PeerAddress> set = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(key));
             set.addAll(peers);
             PeerAddress closest1 = set.iterator().next();
-            PeerAddress closest2 = peerMap.closePeers(key, 1).iterator().next();
+            PeerAddress closest2 = peerMap.closePeers(key, 1).iterator().next().peerAddress();
             if (peerMap.allOverflow().size() == 0) {
                 Assert.assertEquals(closest1, closest2);
             }

--- a/core/src/test/java/net/tomp2p/rpc/TestNeighbor.java
+++ b/core/src/test/java/net/tomp2p/rpc/TestNeighbor.java
@@ -45,7 +45,7 @@ public class TestNeighbor {
             sender = new PeerBuilder(new Number160("0x50")).p2pId(55).ports(2424).start();
             PeerAddress[] pa = Utils2.createDummyAddress(300, PORT_TCP, PORT_UDP);
             for (int i = 0; i < pa.length; i++) {
-                sender.peerBean().peerMap().peerFound(pa[i], null, null);
+                sender.peerBean().peerMap().peerFound(pa[i], null, null, null);
             }
             new NeighborRPC(sender.peerBean(), sender.connectionBean());
             recv1 = new PeerBuilder(new Number160("0x20")).p2pId(55).ports(8088).start();
@@ -87,7 +87,7 @@ public class TestNeighbor {
             sender = new PeerBuilder(new Number160("0x50")).p2pId(55).ports(2424).start();
             PeerAddress[] pa = Utils2.createDummyAddress(300, PORT_TCP, PORT_UDP);
             for (int i = 0; i < pa.length; i++) {
-                sender.peerBean().peerMap().peerFound(pa[i], null, null);
+                sender.peerBean().peerMap().peerFound(pa[i], null, null, null);
             }
             new NeighborRPC(sender.peerBean(), sender.connectionBean());
             recv1 = new PeerBuilder(new Number160("0x20")).p2pId(55).ports(8088).start();

--- a/core/src/test/java/net/tomp2p/rpc/TestPing.java
+++ b/core/src/test/java/net/tomp2p/rpc/TestPing.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 public class TestPing {
     static Bindings bindings = new Bindings();
     static {
-        bindings.addInterface("lo");
+        //bindings.addInterface("lo");
     }
 
     @Test

--- a/dht/src/main/java/net/tomp2p/dht/ParallelRequestBuilder.java
+++ b/dht/src/main/java/net/tomp2p/dht/ParallelRequestBuilder.java
@@ -58,10 +58,10 @@ public class ParallelRequestBuilder<K extends FutureDHT<?>> extends
 
     public ParallelRequestBuilder<K> add(PeerAddress peerAddress) {
         if (directHits == null) {
-        	directHits = new TreeSet<PeerAddress>(peer.peer().peerBean().peerMap().createComparator());
+        	directHits = new TreeSet<PeerAddress>(peer.peer().peerBean().peerMap().createXORAddressComparator());
         }
         if (potentialHits == null) {
-        	potentialHits = new TreeSet<PeerAddress>(peer.peer().peerBean().peerMap().createComparator());
+        	potentialHits = new TreeSet<PeerAddress>(peer.peer().peerBean().peerMap().createXORAddressComparator());
         }
         potentialHits.add(peerAddress);
         return this;

--- a/dht/src/test/java/net/tomp2p/dht/TestDHT.java
+++ b/dht/src/test/java/net/tomp2p/dht/TestDHT.java
@@ -171,8 +171,8 @@ public class TestDHT {
 			Assert.assertEquals(true, fp.isSuccess());
 			peers[30].peerBean().peerMap();
 			// search top 3
-			TreeMap<PeerAddress, Integer> tmp = new TreeMap<PeerAddress, Integer>(PeerMap.createComparator(peers[30]
-			        .peer().peerID()));
+			TreeMap<PeerAddress, Integer> tmp = new TreeMap<PeerAddress, Integer>(PeerMap.createXORAddressComparator(peers[30]
+                    .peer().peerID()));
 			int i = 0;
 			for (PeerDHT node : peers) {
 				tmp.put(node.peer().peerAddress(), i);
@@ -270,8 +270,8 @@ public class TestDHT {
 			Assert.assertEquals(true, fdht.isSuccess());
 			peers[30].peerBean().peerMap();
 			// search top 3
-			TreeMap<PeerAddress, Integer> tmp = new TreeMap<PeerAddress, Integer>(PeerMap.createComparator(peers[30]
-			        .peerID()));
+			TreeMap<PeerAddress, Integer> tmp = new TreeMap<PeerAddress, Integer>(PeerMap.createXORAddressComparator(peers[30]
+                    .peerID()));
 			int i = 0;
 			for (PeerDHT node : peers) {
 				tmp.put(node.peerAddress(), i);
@@ -1029,12 +1029,12 @@ public class TestDHT {
 			master2 = new PeerBuilderDHT(new PeerBuilder(new Number160(rnd)).p2pId(1).ports(4002).start()).start();
 			master3 = new PeerBuilderDHT(new PeerBuilder(new Number160(rnd)).p2pId(1).ports(4003).start()).start();
 			// perfect routing
-			master1.peerBean().peerMap().peerFound(master2.peerAddress(), null, null);
-			master1.peerBean().peerMap().peerFound(master3.peerAddress(), null, null);
-			master2.peerBean().peerMap().peerFound(master1.peerAddress(), null, null);
-			master2.peerBean().peerMap().peerFound(master3.peerAddress(), null, null);
-			master3.peerBean().peerMap().peerFound(master1.peerAddress(), null, null);
-			master3.peerBean().peerMap().peerFound(master2.peerAddress(), null, null);
+			master1.peerBean().peerMap().peerFound(master2.peerAddress(), null, null, null);
+			master1.peerBean().peerMap().peerFound(master3.peerAddress(), null, null, null);
+			master2.peerBean().peerMap().peerFound(master1.peerAddress(), null, null, null);
+			master2.peerBean().peerMap().peerFound(master3.peerAddress(), null, null, null);
+			master3.peerBean().peerMap().peerFound(master1.peerAddress(), null, null, null);
+			master3.peerBean().peerMap().peerFound(master2.peerAddress(), null, null, null);
 			Number160 id = master2.peerID();
 			Data data = new Data(new byte[44444]);
 			RoutingConfiguration rc = new RoutingConfiguration(2, 10, 2);
@@ -1062,10 +1062,10 @@ public class TestDHT {
 			master1.peerBean().peerMap().peerFailed(master2.peerAddress(), new PeerException(AbortCause.SHUTDOWN, "shutdown"));
 			master3.peerBean().peerMap().peerFailed(master2.peerAddress(), new PeerException(AbortCause.SHUTDOWN, "shutdown"));
 			master2 = new PeerBuilderDHT(new PeerBuilder(new Number160(rnd)).p2pId(1).ports(4002).start()).start();
-			master1.peerBean().peerMap().peerFound(master2.peerAddress(), null, null);
-			master3.peerBean().peerMap().peerFound(master2.peerAddress(), null, null);
-			master2.peerBean().peerMap().peerFound(master1.peerAddress(), null, null);
-			master2.peerBean().peerMap().peerFound(master3.peerAddress(), null, null);
+			master1.peerBean().peerMap().peerFound(master2.peerAddress(), null, null, null);
+			master3.peerBean().peerMap().peerFound(master2.peerAddress(), null, null, null);
+			master2.peerBean().peerMap().peerFound(master1.peerAddress(), null, null, null);
+			master2.peerBean().peerMap().peerFound(master3.peerAddress(), null, null, null);
 
 			System.err.println("no more exceptions here!!");
 
@@ -1323,7 +1323,7 @@ public class TestDHT {
 		Peer p2 = null;
 		try {
 			// setup (step 1)
-			Bindings b = new Bindings().addInterface("lo");
+			Bindings b = new Bindings();
 			p1 = new PeerBuilder(new Number160(rnd)).ports(4001).bindings(b).start();
 			p2 = new PeerBuilder(new Number160(rnd)).ports(4002).bindings(b).start();
 			FutureBootstrap fb = p2.bootstrap().peerAddress(p1.peerAddress()).start();

--- a/dht/src/test/java/net/tomp2p/dht/TestSecurity.java
+++ b/dht/src/test/java/net/tomp2p/dht/TestSecurity.java
@@ -12,8 +12,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.crypto.Cipher;
 
-import net.tomp2p.connection.*;
+import net.tomp2p.connection.ChannelClientConfiguration;
 import net.tomp2p.connection.ChannelServerConfiguration;
+import net.tomp2p.connection.DSASignatureFactory;
+import net.tomp2p.connection.RSASignatureFactory;
+import net.tomp2p.connection.SignatureFactory;
 import net.tomp2p.dht.StorageLayer.ProtectionEnable;
 import net.tomp2p.dht.StorageLayer.ProtectionMode;
 import net.tomp2p.message.RSASignatureCodec;
@@ -60,8 +63,8 @@ public class TestSecurity {
             slave1 = new PeerBuilderDHT(new PeerBuilder(new Number160(rnd)).keyPair(pair2).masterPeer(master.peer()).start()).storageLayer(sl).start();
             
             // perfect routing
-            boolean peerInMap1 = master.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null);
-            boolean peerInMap2 = slave1.peerBean().peerMap().peerFound(master.peerAddress(), null, null);
+            boolean peerInMap1 = master.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null, null);
+            boolean peerInMap2 = slave1.peerBean().peerMap().peerFound(master.peerAddress(), null, null, null);
             Assert.assertEquals(true, peerInMap1);
             Assert.assertEquals(true, peerInMap2);
             //
@@ -152,14 +155,14 @@ public class TestSecurity {
                     .protection(ProtectionEnable.ALL, ProtectionMode.MASTER_PUBLIC_KEY, ProtectionEnable.ALL,
                             ProtectionMode.MASTER_PUBLIC_KEY);
             // perfect routing
-            master.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null);
-            master.peerBean().peerMap().peerFound(slave2.peerAddress(), null, null);
+            master.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null, null);
+            master.peerBean().peerMap().peerFound(slave2.peerAddress(), null, null, null);
             //
-            slave1.peerBean().peerMap().peerFound(master.peerAddress(), null, null);
-            slave1.peerBean().peerMap().peerFound(slave2.peerAddress(), null, null);
+            slave1.peerBean().peerMap().peerFound(master.peerAddress(), null, null, null);
+            slave1.peerBean().peerMap().peerFound(slave2.peerAddress(), null, null, null);
             //
-            slave2.peerBean().peerMap().peerFound(master.peerAddress(), null, null);
-            slave2.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null);
+            slave2.peerBean().peerMap().peerFound(master.peerAddress(), null, null, null);
+            slave2.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null, null);
             Number160 locationKey = new Number160(50);
             FuturePut fdht1 = master.put(locationKey).data(new Number160(10), new Data("test1"))
                     .domainKey(Utils.makeSHAHash(pair3.getPublic().getEncoded())).protectDomain().start();
@@ -218,14 +221,14 @@ public class TestSecurity {
                     .protection(ProtectionEnable.ALL, ProtectionMode.MASTER_PUBLIC_KEY, ProtectionEnable.ALL,
                             ProtectionMode.MASTER_PUBLIC_KEY);
             // perfect routing
-            master.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null);
-            master.peerBean().peerMap().peerFound(slave2.peerAddress(), null, null);
+            master.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null, null);
+            master.peerBean().peerMap().peerFound(slave2.peerAddress(), null, null, null);
             //
-            slave1.peerBean().peerMap().peerFound(master.peerAddress(), null, null);
-            slave1.peerBean().peerMap().peerFound(slave2.peerAddress(), null, null);
+            slave1.peerBean().peerMap().peerFound(master.peerAddress(), null, null, null);
+            slave1.peerBean().peerMap().peerFound(slave2.peerAddress(), null, null, null);
             //
-            slave2.peerBean().peerMap().peerFound(master.peerAddress(), null, null);
-            slave2.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null);
+            slave2.peerBean().peerMap().peerFound(master.peerAddress(), null, null, null);
+            slave2.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null, null);
             Number160 locationKey = new Number160(50);
             FuturePut fdht1 = master.put(locationKey).data(new Data("test1"))
                     .domainKey(Utils.makeSHAHash(pair1.getPublic().getEncoded())).protectDomain().start();
@@ -280,8 +283,8 @@ public class TestSecurity {
             slave1 = new PeerBuilderDHT(new PeerBuilder(new Number160(rnd)).keyPair(pair2).masterPeer(master.peer()).start()).storageLayer(sls).start();
             
             // perfect routing
-            boolean peerInMap1 = master.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null);
-            boolean peerInMap2 = slave1.peerBean().peerMap().peerFound(master.peerAddress(), null, null);
+            boolean peerInMap1 = master.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null, null);
+            boolean peerInMap2 = slave1.peerBean().peerMap().peerFound(master.peerAddress(), null, null, null);
             Assert.assertEquals(true, peerInMap1);
             Assert.assertEquals(true, peerInMap2);
 
@@ -336,14 +339,14 @@ public class TestSecurity {
                     .protection(ProtectionEnable.ALL, ProtectionMode.MASTER_PUBLIC_KEY, ProtectionEnable.ALL,
                             ProtectionMode.MASTER_PUBLIC_KEY);
             // perfect routing
-            master.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null);
-            master.peerBean().peerMap().peerFound(slave2.peerAddress(), null, null);
+            master.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null, null);
+            master.peerBean().peerMap().peerFound(slave2.peerAddress(), null, null, null);
             //
-            slave1.peerBean().peerMap().peerFound(master.peerAddress(), null, null);
-            slave1.peerBean().peerMap().peerFound(slave2.peerAddress(), null, null);
+            slave1.peerBean().peerMap().peerFound(master.peerAddress(), null, null, null);
+            slave1.peerBean().peerMap().peerFound(slave2.peerAddress(), null, null, null);
             //
-            slave2.peerBean().peerMap().peerFound(master.peerAddress(), null, null);
-            slave2.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null);
+            slave2.peerBean().peerMap().peerFound(master.peerAddress(), null, null, null);
+            slave2.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null, null);
             Number160 locationKey = new Number160(50);
 
             Data data1 = new Data("test1");

--- a/dht/src/test/java/net/tomp2p/dht/TestStorageDHT.java
+++ b/dht/src/test/java/net/tomp2p/dht/TestStorageDHT.java
@@ -84,7 +84,7 @@ public class TestStorageDHT {
             sender = new PeerBuilderDHT(new PeerBuilder(new Number160("0x50")).p2pId(55).ports(2424).start()).start();
             PeerAddress[] pa = UtilsDHT2.createDummyAddress(300, PORT_TCP, PORT_UDP);
             for (int i = 0; i < pa.length; i++) {
-                sender.peerBean().peerMap().peerFound(pa[i], null, null);
+                sender.peerBean().peerMap().peerFound(pa[i], null, null, null);
             }
             new NeighborRPC(sender.peerBean(), sender.peer().connectionBean());
             recv1 = new PeerBuilderDHT(new PeerBuilder(new Number160("0x20")).p2pId(55).ports(8088).start()).start();

--- a/dht/src/test/java/net/tomp2p/dht/TestStorageMemoryReplication.java
+++ b/dht/src/test/java/net/tomp2p/dht/TestStorageMemoryReplication.java
@@ -1,6 +1,5 @@
 package net.tomp2p.dht;
 
-import net.tomp2p.dht.StorageMemory;
 import net.tomp2p.peers.Number160;
 
 import org.junit.Assert;

--- a/dht/src/test/java/net/tomp2p/dht/UtilsDHT2.java
+++ b/dht/src/test/java/net/tomp2p/dht/UtilsDHT2.java
@@ -31,8 +31,8 @@ import java.util.TreeSet;
 import net.tomp2p.connection.Bindings;
 import net.tomp2p.futures.FutureBootstrap;
 import net.tomp2p.futures.FutureDiscover;
-import net.tomp2p.message.Message.Type;
 import net.tomp2p.message.Message;
+import net.tomp2p.message.Message.Type;
 import net.tomp2p.p2p.AutomaticFuture;
 import net.tomp2p.p2p.Peer;
 import net.tomp2p.p2p.PeerBuilder;
@@ -211,7 +211,7 @@ public class UtilsDHT2 {
     public static void perfectRouting(PeerDHT... peers) {
         for (int i = 0; i < peers.length; i++) {
             for (int j = 0; j < peers.length; j++)
-                peers[i].peer().peerBean().peerMap().peerFound(peers[j].peer().peerAddress(), null, null);
+                peers[i].peer().peerBean().peerMap().peerFound(peers[j].peer().peerAddress(), null, null, null);
         }
         System.err.println("perfect routing done.");
     }
@@ -219,7 +219,7 @@ public class UtilsDHT2 {
     public static void perfectRoutingIndirect(PeerDHT... peers) {
         for (int i = 0; i < peers.length; i++) {
             for (int j = 0; j < peers.length; j++)
-                peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), peers[j].peerAddress(), null);
+                peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), peers[j].peerAddress(), null, null);
         }
         System.err.println("perfect routing done.");
     }
@@ -280,8 +280,8 @@ public class UtilsDHT2 {
 
     public static void routing(Number160 key, Peer[] peers, int start) {
         System.out.println("routing: searching for key " + key);
-        NavigableSet<PeerAddress> pa1 = new TreeSet<PeerAddress>(PeerMap.createComparator(key));
-        NavigableSet<PeerAddress> queried = new TreeSet<PeerAddress>(PeerMap.createComparator(key));
+        NavigableSet<PeerAddress> pa1 = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(key));
+        NavigableSet<PeerAddress> queried = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(key));
         Number160 result = Number160.ZERO;
         Number160 resultPeer = new Number160("0xd75d1a3d57841fbc9e2a3d175d6a35dc2e15b9f");
         int round = 0;

--- a/examples/src/main/java/net/tomp2p/examples/ExampleConsistency.java
+++ b/examples/src/main/java/net/tomp2p/examples/ExampleConsistency.java
@@ -25,8 +25,8 @@ import java.util.TreeSet;
 
 import net.tomp2p.dht.FutureGet;
 import net.tomp2p.dht.FuturePut;
-import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.PeerBuilderDHT;
+import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.p2p.PeerBuilder;
 import net.tomp2p.p2p.RequestP2PConfiguration;
 import net.tomp2p.p2p.Statistics;
@@ -97,7 +97,7 @@ public final class ExampleConsistency {
             ClassNotFoundException {
         System.out.println("key is " + key1);
         // find close peers
-        NavigableSet<PeerAddress> set = new TreeSet<PeerAddress>(PeerMap.createComparator(key1));
+        NavigableSet<PeerAddress> set = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(key1));
         for (PeerDHT peer : peers) {
             set.add(peer.peerAddress());
         }

--- a/examples/src/main/java/net/tomp2p/examples/ExampleDNS.java
+++ b/examples/src/main/java/net/tomp2p/examples/ExampleDNS.java
@@ -18,8 +18,8 @@ package net.tomp2p.examples;
 import java.io.IOException;
 
 import net.tomp2p.dht.FutureGet;
-import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.PeerBuilderDHT;
+import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.futures.FutureBootstrap;
 import net.tomp2p.p2p.PeerBuilder;
 import net.tomp2p.peers.Number160;

--- a/examples/src/main/java/net/tomp2p/examples/ExampleDST.java
+++ b/examples/src/main/java/net/tomp2p/examples/ExampleDST.java
@@ -30,8 +30,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import net.tomp2p.dht.FutureGet;
 import net.tomp2p.dht.FuturePut;
-import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.PeerBuilderDHT;
+import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.StorageLayer;
 import net.tomp2p.dht.StorageMemory;
 import net.tomp2p.p2p.Peer;

--- a/examples/src/main/java/net/tomp2p/examples/ExampleDirectData.java
+++ b/examples/src/main/java/net/tomp2p/examples/ExampleDirectData.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import net.tomp2p.dht.FutureSend;
-import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.PeerBuilderDHT;
+import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.futures.BaseFutureListener;
 import net.tomp2p.p2p.PeerBuilder;
 import net.tomp2p.p2p.RequestP2PConfiguration;

--- a/examples/src/main/java/net/tomp2p/examples/ExampleDomainProtection.java
+++ b/examples/src/main/java/net/tomp2p/examples/ExampleDomainProtection.java
@@ -8,8 +8,8 @@ import java.util.Random;
 
 import net.tomp2p.dht.FutureGet;
 import net.tomp2p.dht.FuturePut;
-import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.PeerBuilderDHT;
+import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.StorageLayer.ProtectionEnable;
 import net.tomp2p.dht.StorageLayer.ProtectionMode;
 import net.tomp2p.p2p.PeerBuilder;

--- a/examples/src/main/java/net/tomp2p/examples/ExampleIndirectReplication.java
+++ b/examples/src/main/java/net/tomp2p/examples/ExampleIndirectReplication.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 
 import net.tomp2p.dht.FutureDigest;
 import net.tomp2p.dht.FuturePut;
-import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.PeerBuilderDHT;
+import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.p2p.PeerBuilder;
 import net.tomp2p.peers.Number160;
 import net.tomp2p.replication.IndirectReplication;

--- a/examples/src/main/java/net/tomp2p/examples/ExampleNATChat.java
+++ b/examples/src/main/java/net/tomp2p/examples/ExampleNATChat.java
@@ -8,8 +8,8 @@ import java.util.Random;
 
 import net.tomp2p.connection.Bindings;
 import net.tomp2p.dht.FutureGet;
-import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.PeerBuilderDHT;
+import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.futures.FutureBootstrap;
 import net.tomp2p.futures.FutureDiscover;
 import net.tomp2p.p2p.PeerBuilder;

--- a/examples/src/main/java/net/tomp2p/examples/ExampleReconnect.java
+++ b/examples/src/main/java/net/tomp2p/examples/ExampleReconnect.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.PeerBuilderDHT;
+import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.p2p.Peer;
 import net.tomp2p.p2p.PeerBuilder;
 import net.tomp2p.peers.Number160;

--- a/examples/src/main/java/net/tomp2p/examples/ExampleUtils.java
+++ b/examples/src/main/java/net/tomp2p/examples/ExampleUtils.java
@@ -18,8 +18,8 @@ package net.tomp2p.examples;
 import java.io.IOException;
 import java.util.Random;
 
-import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.PeerBuilderDHT;
+import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.p2p.Peer;
 import net.tomp2p.p2p.PeerBuilder;
 import net.tomp2p.peers.Number160;
@@ -43,7 +43,7 @@ public class ExampleUtils {
     	//make perfect bootstrap, the regular can take a while
     	for(int i=0;i<peers.length;i++) {
     		for(int j=0;j<peers.length;j++) {
-    			peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), null, null);
+    			peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), null, null, null);
     		}
     	}
     }
@@ -52,7 +52,7 @@ public class ExampleUtils {
     	//make perfect bootstrap, the regular can take a while
     	for(int i=0;i<peers.length;i++) {
     		for(int j=0;j<peers.length;j++) {
-    			peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), null, null);
+    			peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), null, null, null);
     		}
     	}
     }

--- a/examples/src/main/java/net/tomp2p/examples/SeedNodeForTesting.java
+++ b/examples/src/main/java/net/tomp2p/examples/SeedNodeForTesting.java
@@ -24,6 +24,7 @@ import net.tomp2p.p2p.PeerBuilder;
 import net.tomp2p.peers.Number160;
 import net.tomp2p.peers.PeerAddress;
 import net.tomp2p.rpc.ObjectDataReply;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/nat/src/main/java/net/tomp2p/holep/DuplicatesHandler.java
+++ b/nat/src/main/java/net/tomp2p/holep/DuplicatesHandler.java
@@ -1,13 +1,14 @@
 package net.tomp2p.holep;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
 
 import net.tomp2p.connection.Dispatcher;
 import net.tomp2p.message.Message;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.ChannelHandler.Sharable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Sharable
 public class DuplicatesHandler extends SimpleChannelInboundHandler<Message>{

--- a/nat/src/main/java/net/tomp2p/holep/HolePunchRPC.java
+++ b/nat/src/main/java/net/tomp2p/holep/HolePunchRPC.java
@@ -3,9 +3,6 @@ package net.tomp2p.holep;
 import java.util.ArrayList;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import net.tomp2p.connection.Dispatcher;
 import net.tomp2p.connection.HolePunchInitiator;
 import net.tomp2p.connection.PeerConnection;
@@ -21,6 +18,9 @@ import net.tomp2p.relay.BaseRelayForwarderRPC;
 import net.tomp2p.rpc.DispatchHandler;
 import net.tomp2p.rpc.RPC;
 import net.tomp2p.rpc.RPC.Commands;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Jonas Wagner

--- a/nat/src/main/java/net/tomp2p/holep/HolePuncher.java
+++ b/nat/src/main/java/net/tomp2p/holep/HolePuncher.java
@@ -456,7 +456,7 @@ public class HolePuncher {
 			peer.connectionBean().sender().afterConnect(futureResponse, dummyMessage, channelFutures.get(i), FIRE_AND_FORGET_VALUE);
 			// this is a workaround to avoid adding a nat peer to the offline
 			// list of a peer!
-			peer.peerBean().peerMap().peerFound(originalSender, originalSender, null);
+			peer.peerBean().peerMap().peerFound(originalSender, originalSender, null, null);
 		}
 	}
 }

--- a/nat/src/main/java/net/tomp2p/holep/testapp/HolePTestApp.java
+++ b/nat/src/main/java/net/tomp2p/holep/testapp/HolePTestApp.java
@@ -2,14 +2,10 @@ package net.tomp2p.holep.testapp;
 
 import java.io.IOException;
 import java.net.Inet4Address;
-import java.util.Scanner;
 
 import net.tomp2p.futures.BaseFutureAdapter;
 import net.tomp2p.futures.FutureBootstrap;
 import net.tomp2p.futures.FutureDirect;
-import net.tomp2p.futures.FutureResponse;
-import net.tomp2p.futures.FutureShutdown;
-import net.tomp2p.message.Buffer;
 import net.tomp2p.nat.FutureRelayNAT;
 import net.tomp2p.nat.PeerBuilderNAT;
 import net.tomp2p.nat.PeerNAT;

--- a/nat/src/main/java/net/tomp2p/holep/testapp/HolePTestDriver.java
+++ b/nat/src/main/java/net/tomp2p/holep/testapp/HolePTestDriver.java
@@ -1,9 +1,9 @@
 package net.tomp2p.holep.testapp;
 
+import ch.qos.logback.classic.Level;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import ch.qos.logback.classic.Level;
 
 public class HolePTestDriver {
 

--- a/nat/src/main/java/net/tomp2p/holep/testapp/HolePTestView.java
+++ b/nat/src/main/java/net/tomp2p/holep/testapp/HolePTestView.java
@@ -1,19 +1,8 @@
 package net.tomp2p.holep.testapp;
 
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.FlowLayout;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.awt.Label;
+import java.awt.*;
 
-import javax.swing.JButton;
-import javax.swing.JFrame;
-import javax.swing.JPanel;
-import javax.swing.JTextArea;
-import javax.swing.JTextField;
+import javax.swing.*;
 
 public class HolePTestView extends JFrame {
 

--- a/nat/src/main/java/net/tomp2p/holep/testapp/PanelSettings.java
+++ b/nat/src/main/java/net/tomp2p/holep/testapp/PanelSettings.java
@@ -1,10 +1,8 @@
 package net.tomp2p.holep.testapp;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.LayoutManager;
+import java.awt.*;
 
-import javax.swing.JPanel;
+import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 
 public class PanelSettings {

--- a/nat/src/main/java/net/tomp2p/relay/RelayUtils.java
+++ b/nat/src/main/java/net/tomp2p/relay/RelayUtils.java
@@ -61,7 +61,7 @@ public class RelayUtils {
 		PeerMapConfiguration peerMapConfiguration = new PeerMapConfiguration(sender.peerId());
 		PeerMap peerMap = new PeerMap(peerMapConfiguration);
 		for (PeerAddress peerAddress : map) {
-			peerMap.peerFound(peerAddress, null, null);
+			peerMap.peerFound(peerAddress, null, null, null);
 		}
 		return peerMap.peerMapVerified();
 	}

--- a/nat/src/main/java/net/tomp2p/relay/android/gcm/GCMSenderRPC.java
+++ b/nat/src/main/java/net/tomp2p/relay/android/gcm/GCMSenderRPC.java
@@ -3,6 +3,8 @@ package net.tomp2p.relay.android.gcm;
 import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
 
+import com.google.android.gcm.server.Result;
+import com.google.android.gcm.server.Sender;
 import net.tomp2p.connection.Dispatcher;
 import net.tomp2p.connection.PeerConnection;
 import net.tomp2p.connection.Responder;
@@ -18,9 +20,6 @@ import net.tomp2p.rpc.RPC;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.android.gcm.server.Result;
-import com.google.android.gcm.server.Sender;
 
 /**
  * This RPC is dedicated to send messages over Google Cloud Messaging. It's only used if

--- a/nat/src/test/java/net/tomp2p/relay/UtilsNAT.java
+++ b/nat/src/test/java/net/tomp2p/relay/UtilsNAT.java
@@ -116,7 +116,7 @@ public class UtilsNAT {
 	public static void perfectRouting(PeerDHT... peers) {
 		for (int i = 0; i < peers.length; i++) {
 			for (int j = 0; j < peers.length; j++)
-				peers[i].peer().peerBean().peerMap().peerFound(peers[j].peer().peerAddress(), null, null);
+				peers[i].peer().peerBean().peerMap().peerFound(peers[j].peer().peerAddress(), null, null, null);
 		}
 		System.err.println("perfect routing done.");
 	}
@@ -194,7 +194,7 @@ public class UtilsNAT {
 	public static void perfectRouting(Peer... peers) {
 		for (int i = 0; i < peers.length; i++) {
 			for (int j = 0; j < peers.length; j++)
-				peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), null, null);
+				peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), null, null, null);
 		}
 		System.err.println("perfect routing done.");
 	}

--- a/replication/src/main/java/net/tomp2p/replication/IndirectReplication.java
+++ b/replication/src/main/java/net/tomp2p/replication/IndirectReplication.java
@@ -37,6 +37,7 @@ import net.tomp2p.p2p.Shutdown;
 import net.tomp2p.peers.Number160;
 import net.tomp2p.peers.Number640;
 import net.tomp2p.peers.PeerAddress;
+import net.tomp2p.peers.PeerStatistic;
 import net.tomp2p.storage.Data;
 import net.tomp2p.synchronization.PeerSync;
 import net.tomp2p.utils.Utils;
@@ -342,13 +343,13 @@ public class IndirectReplication implements ResponsibilityListener, Runnable {
     protected List<PeerAddress> send(final Number160 locationKey, final Map<Number640, Data> dataMapConverted) {
         int replicationFactor = replication.replicationFactor() - 1;
         List<PeerAddress> closePeers = new ArrayList<PeerAddress>();
-        SortedSet<PeerAddress> sortedSet = peer.peerBean().peerMap()
+        SortedSet<PeerStatistic> sortedSet = peer.peerBean().peerMap()
                 .closePeers(locationKey, replicationFactor);
         int count = 0;
-        for (PeerAddress peerAddress : sortedSet) {
+        for (PeerStatistic peerStatistic : sortedSet) {
             count++;
-            closePeers.add(peerAddress);
-            replicationSender.sendDirect(peerAddress, locationKey, dataMapConverted);
+            closePeers.add(peerStatistic.peerAddress());
+            replicationSender.sendDirect(peerStatistic.peerAddress(), locationKey, dataMapConverted);
             if (count == replicationFactor) {
                 break;
             }

--- a/replication/src/main/java/net/tomp2p/replication/Replication.java
+++ b/replication/src/main/java/net/tomp2p/replication/Replication.java
@@ -510,9 +510,9 @@ public class Replication implements PeerMapChangeListener, ReplicationListener {
      * @return The peer that is responsible for the location key, including myself.
      */
     private PeerAddress closest(final Number160 locationKey) {
-        SortedSet<PeerAddress> tmp = peerMap.closePeers(locationKey, 1);
-        tmp.add(selfAddress);
-        return tmp.iterator().next();
+        SortedSet<PeerStatistic> tmp = peerMap.closePeers(locationKey, 1);
+        tmp.add(new PeerStatistic(selfAddress));
+        return tmp.iterator().next().peerAddress();
     }
 
     /**
@@ -529,8 +529,9 @@ public class Replication implements PeerMapChangeListener, ReplicationListener {
      */
     private boolean isInReplicationRange(final Number160 locationKey, final PeerAddress peerAddress,
             final int replicationFactor) {
-        SortedSet<PeerAddress> tmp = peerMap.closePeers(locationKey, replicationFactor);
-        tmp.add(selfAddress);
-        return tmp.headSet(peerAddress).size() < replicationFactor * 2;
+        SortedSet<PeerStatistic> tmp = peerMap.closePeers(locationKey, replicationFactor);
+        PeerStatistic selfStatistic = new PeerStatistic(selfAddress);
+        tmp.add(selfStatistic);
+        return tmp.headSet(selfStatistic).size() < replicationFactor * 2;
     }	
 }

--- a/replication/src/test/java/net/tomp2p/Utils2.java
+++ b/replication/src/test/java/net/tomp2p/Utils2.java
@@ -29,8 +29,8 @@ import java.util.Random;
 import java.util.TreeSet;
 
 import net.tomp2p.connection.Bindings;
-import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.PeerBuilderDHT;
+import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.futures.FutureBootstrap;
 import net.tomp2p.futures.FutureDiscover;
 import net.tomp2p.message.Message;
@@ -140,7 +140,7 @@ public class Utils2 {
         if (nrOfPeers < 1) {
             throw new IllegalArgumentException("Cannot create less than 1 peer");
         }
-        Bindings bindings = new Bindings().addInterface("lo");
+        Bindings bindings = new Bindings();
         PeerDHT[] peers = new PeerDHT[nrOfPeers];
         
         PeerBuilder pm = new PeerBuilder(new Number160(rnd))
@@ -204,7 +204,7 @@ public class Utils2 {
     public static void perfectRouting(PeerDHT... peers) {
         for (int i = 0; i < peers.length; i++) {
             for (int j = 0; j < peers.length; j++)
-                peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), null, null);
+                peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), null, null, null);
         }
         System.err.println("perfect routing done.");
     }
@@ -212,7 +212,7 @@ public class Utils2 {
     public static void perfectRoutingIndirect(Peer... peers) {
         for (int i = 0; i < peers.length; i++) {
             for (int j = 0; j < peers.length; j++)
-                peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), peers[j].peerAddress(), null);
+                peers[i].peerBean().peerMap().peerFound(peers[j].peerAddress(), peers[j].peerAddress(), null, null);
         }
         System.err.println("perfect routing done.");
     }
@@ -273,8 +273,8 @@ public class Utils2 {
 
     public static void routing(Number160 key, Peer[] peers, int start) {
         System.out.println("routing: searching for key " + key);
-        NavigableSet<PeerAddress> pa1 = new TreeSet<PeerAddress>(PeerMap.createComparator(key));
-        NavigableSet<PeerAddress> queried = new TreeSet<PeerAddress>(PeerMap.createComparator(key));
+        NavigableSet<PeerAddress> pa1 = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(key));
+        NavigableSet<PeerAddress> queried = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(key));
         Number160 result = Number160.ZERO;
         Number160 resultPeer = new Number160("0xd75d1a3d57841fbc9e2a3d175d6a35dc2e15b9f");
         int round = 0;

--- a/replication/src/test/java/net/tomp2p/replication/AutomaticReplicationTest.java
+++ b/replication/src/test/java/net/tomp2p/replication/AutomaticReplicationTest.java
@@ -13,8 +13,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import net.tomp2p.Utils2;
-import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.PeerBuilderDHT;
+import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.futures.BaseFuture;
 import net.tomp2p.futures.BaseFutureAdapter;
 import net.tomp2p.futures.FutureDone;
@@ -214,8 +214,8 @@ public class AutomaticReplicationTest {
 
     private NavigableSet<PeerAddress> findTheClosestPeer(PeerDHT[] peers, Number160 locationKey) {
     	
-    	Comparator<PeerAddress> c = PeerMap.createComparator(locationKey);
-    	TreeSet<PeerAddress> ts = new TreeSet<PeerAddress>(c);
+    	Comparator<PeerAddress> c = PeerMap.createXORAddressComparator(locationKey);
+        TreeSet<PeerAddress> ts = new TreeSet<PeerAddress>(c);
     	for(PeerDHT peer:peers) {
     		ts.add(peer.peerAddress());
     	}

--- a/replication/src/test/java/net/tomp2p/replication/SynchronizationTest.java
+++ b/replication/src/test/java/net/tomp2p/replication/SynchronizationTest.java
@@ -12,8 +12,8 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.PeerBuilderDHT;
+import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.futures.BaseFutureAdapter;
 import net.tomp2p.futures.FutureChannelCreator;
 import net.tomp2p.futures.FutureDone;

--- a/replication/src/test/java/net/tomp2p/replication/TestReplication.java
+++ b/replication/src/test/java/net/tomp2p/replication/TestReplication.java
@@ -25,8 +25,8 @@ import java.util.TreeSet;
 
 import net.tomp2p.Utils2;
 import net.tomp2p.dht.FuturePut;
-import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.dht.PeerBuilderDHT;
+import net.tomp2p.dht.PeerDHT;
 import net.tomp2p.futures.BaseFuture;
 import net.tomp2p.futures.FutureBootstrap;
 import net.tomp2p.p2p.AutomaticFuture;
@@ -259,7 +259,7 @@ public class TestReplication {
             Number160 locationKey = new Number160(RND2);
             master.peerBean().peerMap();
             // closest
-            TreeSet<PeerAddress> tmp = new TreeSet<PeerAddress>(PeerMap.createComparator(locationKey));
+            TreeSet<PeerAddress> tmp = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(locationKey));
             tmp.add(master.peerAddress());
             for (int i = 0; i < peers.length; i++) {
                 tmp.add(peers[i].peerAddress());
@@ -326,7 +326,7 @@ public class TestReplication {
     }
     
     private static PeerDHT searchPeer(final Number160 locationKey, final PeerDHT[] peers) {
-        TreeSet<PeerAddress> tmp = new TreeSet<PeerAddress>(PeerMap.createComparator(locationKey));
+        TreeSet<PeerAddress> tmp = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(locationKey));
         for (int i = 0; i < peers.length; i++) {
             tmp.add(peers[i].peerAddress());
         }

--- a/replication/src/test/java/net/tomp2p/replication/TestStoreReplication.java
+++ b/replication/src/test/java/net/tomp2p/replication/TestStoreReplication.java
@@ -106,7 +106,7 @@ public class TestStoreReplication {
             // s1.put(location, Number160.ZERO, null, dataMap, false, false);
             final int slavePort = 7701;
             slave = new PeerBuilderDHT(new PeerBuilder(new Number160("0xfe")).ports(slavePort).start()).start();
-            master.peerBean().peerMap().peerFound(slave.peerAddress(), null, null);
+            master.peerBean().peerMap().peerFound(slave.peerAddress(), null, null, null);
             master.peerBean().peerMap().peerFailed(slave.peerAddress(), new PeerException(AbortCause.SHUTDOWN, "shutdown"));
             Assert.assertEquals(1, test1.get());
             Assert.assertEquals(2, test2.get());
@@ -186,8 +186,8 @@ public class TestStoreReplication {
             System.err.println("slave1 is " + slave1.peerAddress());
             System.err.println("slave2 is " + slave2.peerAddress());
             // master peer learns about the slave peers
-            master.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null);
-            master.peerBean().peerMap().peerFound(slave2.peerAddress(), null, null);
+            master.peerBean().peerMap().peerFound(slave1.peerAddress(), null, null, null);
+            master.peerBean().peerMap().peerFound(slave2.peerAddress(), null, null, null);
 
             System.err.println("both peers online");
             PeerAddress slaveAddress1 = slave1.peerAddress();
@@ -1019,7 +1019,7 @@ public class TestStoreReplication {
 			
 			for (int i = 1; i < joins.length; i++) {
 				// insert a peer
-				master.peerBean().peerMap().peerFound(peers.get(i).peerAddress(), null, null);
+				master.peerBean().peerMap().peerFound(peers.get(i).peerAddress(), null, null, null);
 				// verify replication notifications
 				Assert.assertEquals(joins[i][0], replicateI.get());
 				replicateI.set(0);

--- a/replication/src/test/java/net/tomp2p/replication/UtilsReplication.java
+++ b/replication/src/test/java/net/tomp2p/replication/UtilsReplication.java
@@ -18,7 +18,7 @@ public class UtilsReplication {
         if (nrOfPeers < 1) {
             throw new IllegalArgumentException("Cannot create less than 1 peer");
         }
-        Bindings bindings = new Bindings().addInterface("lo");
+        Bindings bindings = new Bindings();
         PeerDHT[] peers  = new PeerDHT[nrOfPeers];
         final Peer master;
         if (automaticFuture != null) {
@@ -73,7 +73,7 @@ public class UtilsReplication {
 	public static void perfectRouting(PeerDHT... peers) {
         for (int i = 0; i < peers.length; i++) {
             for (int j = 0; j < peers.length; j++)
-                peers[i].peer().peerBean().peerMap().peerFound(peers[j].peer().peerAddress(), null, null);
+                peers[i].peer().peerBean().peerMap().peerFound(peers[j].peer().peerAddress(), null, null, null);
         }
         System.err.println("perfect routing done.");
     }

--- a/tracker/src/main/java/net/tomp2p/tracker/DistributedTracker.java
+++ b/tracker/src/main/java/net/tomp2p/tracker/DistributedTracker.java
@@ -82,7 +82,7 @@ public class DistributedTracker {
 					Collection<Pair<PeerStatistic, Data>> value = trackerStorage.peers(new Number320(builder.locationKey(), builder
 					        .domainKey())).values(); 
 					TrackerData peers = new TrackerData(value);
-					NavigableSet<PeerAddress> queue = new TreeSet<PeerAddress>(PeerMap.createComparator(stableRandom));
+					NavigableSet<PeerAddress> queue = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(stableRandom));
 					if(peers != null && peers.peerAddresses()!=null) {
 						queue.addAll(peers.peerAddresses().keySet());
 					}
@@ -177,7 +177,7 @@ public class DistributedTracker {
 	        TrackerConfiguration trackerConfiguration, FutureTracker futureTracker, boolean isGet,
 	        final Set<Number160> knownPeers, Operation operation) {
 		FutureResponse[] futureResponses = new FutureResponse[trackerConfiguration.parallel()];
-		NavigableSet<PeerAddress> secondaryQueue = new TreeSet<PeerAddress>(PeerMap.createComparator(stableRandom));
+		NavigableSet<PeerAddress> secondaryQueue = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(stableRandom));
 		loopRec(locationKey, domainKey, queueToAsk, secondaryQueue, new HashSet<PeerAddress>(),
 		        new HashSet<PeerAddress>(), new HashMap<PeerAddress, TrackerData>(), operation,
 		        trackerConfiguration.parallel(), new AtomicInteger(0), trackerConfiguration.maxFailure(),

--- a/tracker/src/test/java/net/tomp2p/tracker/TestTracker.java
+++ b/tracker/src/test/java/net/tomp2p/tracker/TestTracker.java
@@ -29,7 +29,7 @@ public class TestTracker {
             // perfect routing
             for (int i = 0; i < nodes.length; i++) {
                 for (int j = 0; j < nodes.length; j++)
-                    nodes[i].peer().peerBean().peerMap().peerFound(nodes[j].peerAddress(), null, null);
+                    nodes[i].peer().peerBean().peerMap().peerFound(nodes[j].peerAddress(), null, null, null);
             }
             RoutingConfiguration rc = new RoutingConfiguration(0, 1, 1);
             TrackerConfiguration tc = new TrackerConfiguration(1, 1, 1, 0);
@@ -59,7 +59,7 @@ public class TestTracker {
     }
 
     private static PeerTracker findClosest(PeerTracker[] nodes, Number160 trackerID) {
-    	TreeSet<PeerAddress> set = new TreeSet<PeerAddress>(PeerMap.createComparator(trackerID));
+    	TreeSet<PeerAddress> set = new TreeSet<PeerAddress>(PeerMap.createXORAddressComparator(trackerID));
     	for(PeerTracker p:nodes) {
     		set.add(p.peerAddress());
     	}
@@ -83,7 +83,7 @@ public class TestTracker {
             // perfect routing
             for (int i = 0; i < nodes.length; i++) {
                 for (int j = 0; j < nodes.length; j++)
-                    nodes[i].peer().peerBean().peerMap().peerFound(nodes[j].peerAddress(), null, null);
+                    nodes[i].peer().peerBean().peerMap().peerFound(nodes[j].peerAddress(), null, null, null);
             }
             RoutingConfiguration rc = new RoutingConfiguration(1, 1, 1);
             TrackerConfiguration tc = new TrackerConfiguration(1, 1, 2, 0, 1000, 2);
@@ -123,7 +123,7 @@ public class TestTracker {
             // perfect routing
             for (int i = 0; i < nodes.length; i++) {
                 for (int j = 0; j < nodes.length; j++)
-                    nodes[i].peer().peerBean().peerMap().peerFound(nodes[j].peerAddress(), null, null);
+                    nodes[i].peer().peerBean().peerMap().peerFound(nodes[j].peerAddress(), null, null, null);
             }
             RoutingConfiguration rc = new RoutingConfiguration(1, 1, 1);
             TrackerConfiguration tc = new TrackerConfiguration(1, 1, 2, 0, 1000, 2);
@@ -161,7 +161,7 @@ public class TestTracker {
             // perfect routing
             for (int i = 0; i < nodes.length; i++) {
                 for (int j = 0; j < nodes.length; j++)
-                    nodes[i].peer().peerBean().peerMap().peerFound(nodes[j].peerAddress(), null, null);
+                    nodes[i].peer().peerBean().peerMap().peerFound(nodes[j].peerAddress(), null, null, null);
             }
             RoutingConfiguration rc = new RoutingConfiguration(1, 1, 1);
             TrackerConfiguration tc = new TrackerConfiguration(1, 1, 2, 0);
@@ -211,7 +211,7 @@ public class TestTracker {
                 // nodes[i].getPeerBean().getTrackerStorage()
                 // .setTrackerStoreSize(nodes[i].getPeerBean().getTrackerStorage().getTrackerSize());
                 for (int j = 0; j < nodes.length; j++)
-                    nodes[i].peer().peerBean().peerMap().peerFound(nodes[j].peerAddress(), null, null);
+                    nodes[i].peer().peerBean().peerMap().peerFound(nodes[j].peerAddress(), null, null, null);
             }
             RoutingConfiguration rc = new RoutingConfiguration(1, 1, 1);
             // 3 is good!
@@ -295,7 +295,7 @@ public class TestTracker {
             // perfect routing
             for (int i = 0; i < nodes.length; i++) {
                 for (int j = 0; j < nodes.length; j++)
-                    nodes[i].peer().peerBean().peerMap().peerFound(nodes[j].peerAddress(), null, null);
+                    nodes[i].peer().peerBean().peerMap().peerFound(nodes[j].peerAddress(), null, null, null);
             }
             RoutingConfiguration rc = new RoutingConfiguration(1, 1, 1);
             TrackerConfiguration tc = new TrackerConfiguration(1, 1, 2, 0);
@@ -377,7 +377,7 @@ public class TestTracker {
             for (int i = 0; i < nodes.length; i++) {
                 for (int j = 0; j < nodes.length; j++) {
                     if (i != j)
-                        nodes[i].peer().peerBean().peerMap().peerFound(nodes[j].peerAddress(), null, null);
+                        nodes[i].peer().peerBean().peerMap().peerFound(nodes[j].peerAddress(), null, null, null);
                 }
             }
             FutureTracker ft = nodes[30].getTracker(trackerID).start();

--- a/tracker/src/test/java/net/tomp2p/tracker/TestTrackerRPC.java
+++ b/tracker/src/test/java/net/tomp2p/tracker/TestTrackerRPC.java
@@ -43,7 +43,7 @@ public class TestTrackerRPC {
                     addTrackerBuilder, cc);
             fr.awaitUninterruptibly();
             //either you sleep for 1 sec and let the maintenance do its work, or do it manually
-            recv1.peer().peerBean().notifyPeerFound(sender.peerAddress(), null, null);
+            recv1.peer().peerBean().notifyPeerFound(sender.peerAddress(), null, null, null);
             System.err.println(fr.failedReason());
             Assert.assertEquals(true, fr.isSuccess());
             bloomFilter = new SimpleBloomFilter<Number160>(100, 10);
@@ -102,7 +102,7 @@ public class TestTrackerRPC {
                     addTrackerBuilder, cc);
             fr.awaitUninterruptibly();
             //either you sleep for 1 sec and let the maintenance do its work, or do it manually
-            recv1.peer().peerBean().notifyPeerFound(sender.peerAddress(), null, null);
+            recv1.peer().peerBean().notifyPeerFound(sender.peerAddress(), null, null, null);
             Assert.assertEquals(true, fr.isSuccess());
 
             GetTrackerBuilder getTrackerBuilder = new GetTrackerBuilder(sender, loc);
@@ -153,7 +153,7 @@ public class TestTrackerRPC {
                     addTrackerBuilder, cc);
             fr.awaitUninterruptibly();
             //either you sleep for 1 sec and let the maintenance do its work, or do it manually
-            recv1.peer().peerBean().notifyPeerFound(sender.peerAddress(), null, null);
+            recv1.peer().peerBean().notifyPeerFound(sender.peerAddress(), null, null, null);
             Assert.assertEquals(true, fr.isSuccess());
 
             GetTrackerBuilder getTrackerBuilder = new GetTrackerBuilder(sender, loc);
@@ -209,7 +209,7 @@ public class TestTrackerRPC {
                     addTrackerBuilder, cc);
             fr.awaitUninterruptibly();
             //either you sleep for 1 sec and let the maintenance do its work, or do it manually
-            recv1.peer().peerBean().notifyPeerFound(sender.peerAddress(), null, null);
+            recv1.peer().peerBean().notifyPeerFound(sender.peerAddress(), null, null, null);
             Assert.assertEquals(true, fr.isSuccess());
             bloomFilter.add(sender.peerAddress().peerId());
 

--- a/tracker/src/test/java/net/tomp2p/tracker/TestTrackerStorage.java
+++ b/tracker/src/test/java/net/tomp2p/tracker/TestTrackerStorage.java
@@ -66,7 +66,7 @@ public class TestTrackerStorage {
 		Number320 n320 = new Number320(Number160.ZERO, Number160.ZERO);
 
 		trackerStorage.put(n320, selfAddress, null, new Data("test"));
-		trackerStorage.peerFound(selfAddress, null, null);
+		trackerStorage.peerFound(selfAddress, null, null, null);
 		
 		TrackerData td = trackerStorage.trackerData(n320);
 		Object o = td.peerAddresses().values().iterator().next().object();
@@ -87,7 +87,7 @@ public class TestTrackerStorage {
 		KeyPair pair1 = gen.generateKeyPair();
 		
 		trackerStorage.put(n320, selfAddress, pair1.getPublic(), new Data("test"));
-		trackerStorage.peerFound(selfAddress, null, null);
+		trackerStorage.peerFound(selfAddress, null, null, null);
 		trackerStorage.put(n320, selfAddress, pair1.getPublic(), new Data("test1"));
 		
 		TrackerData td = trackerStorage.trackerData(n320);
@@ -152,7 +152,7 @@ public class TestTrackerStorage {
 
 		trackerStorage.put(n320, selfAddress, null, new Data("test"));
 		PeerStatistic ps = trackerStorage.nextForMaintenance(null);
-		trackerStorage.peerFound(selfAddress, null, null);
+		trackerStorage.peerFound(selfAddress, null, null, null);
 		ps = trackerStorage.nextForMaintenance(null);
 		Assert.assertNull(ps);
 	}


### PR DESCRIPTION
This pull request introduces:
* PeerMap bucket sizes can now be configured in the PeerMapConfiguration. The default sizes were changed from 20 for all buckets to 128, 64, 32, 16 for the largest (most distant) buckets and 8 for the remaining buckets.
* The [RTT](https://github.com/sebastian-stephan/TomP2P/blob/add-rtt/core/src/main/java/net/tomp2p/peers/RTT.java) (Round-Trip-Time) of requests are measured and saved in the [PeerStatistic](https://github.com/sebastian-stephan/TomP2P/blob/add-rtt/core/src/main/java/net/tomp2p/peers/PeerStatistic.java) objects in the PeerMap. The RTT from reported peers are estimated using the RTT of the referrer. A moving average of the last 5 measurments is kept at all time.
* A customizable comparator (Interface [PeerStatisticComparator](https://github.com/sebastian-stephan/TomP2P/blob/add-rtt/core/src/main/java/net/tomp2p/p2p/PeerStatisticComparator.java)) can be configured in the PeerMapConfiguration to prioritise peers based on metrics in the PeerStatistic such as average RTT, number of times seen, last time online, etc. This can be used to improve performance and balance load. A sample comparator that prioritises over RTT is also added ([RTTStatisticComparator](https://github.com/sebastian-stephan/TomP2P/blob/add-rtt/core/src/main/java/net/tomp2p/p2p/RTTPeerStatisticComparator.java)). 
* The routing mechanism will use the above comparator during the routing process when selecting the next peer to ask. It is also used when sorting peers in a neighbor rpc call.

Additionally some code cleanup has been done such as optimized imports, typos and wrong JavaDoc parameters.