### PR TITLE
Buffered TCP

### DIFF
--- a/android/src/main/java/net/tomp2p/relay/android/AndroidRelayServer.java
+++ b/android/src/main/java/net/tomp2p/relay/android/AndroidRelayServer.java
@@ -2,9 +2,7 @@ package net.tomp2p.relay.android;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import net.tomp2p.futures.FutureDone;
 import net.tomp2p.message.Message;
-import net.tomp2p.message.Message.Type;
 import net.tomp2p.p2p.Peer;
 import net.tomp2p.peers.PeerAddress;
 import net.tomp2p.relay.RelayType;
@@ -42,25 +40,6 @@ public class AndroidRelayServer extends BufferedRelayServer {
 		// stretch the update interval by factor 1.5 to be tolerant for slow messages
 		this.mapUpdateIntervalMS = (int) (mapUpdateIntervalS * 1000 * 1.5);
 		this.lastUpdate = new AtomicLong(System.currentTimeMillis());
-	}
-
-	@Override
-	public FutureDone<Message> forwardToUnreachable(Message message) {
-		// create temporal OK message
-		final FutureDone<Message> futureDone = new FutureDone<Message>();
-		final Message response = createResponseMessage(message, Type.PARTIALLY_OK);
-		response.recipient(message.sender());
-		response.sender(unreachablePeerAddress());
-
-		try {
-			addToBuffer(message);
-		} catch (Exception e) {
-			LOG.error("Cannot encode the message", e);
-			return futureDone.done(createResponseMessage(message, Type.EXCEPTION));
-		}
-
-		LOG.debug("Added message {} to buffer and returning a partially ok", message);
-		return futureDone.done(response);
 	}
 
 	@Override

--- a/android/src/main/java/net/tomp2p/relay/android/AndroidRelayServer.java
+++ b/android/src/main/java/net/tomp2p/relay/android/AndroidRelayServer.java
@@ -1,20 +1,13 @@
 package net.tomp2p.relay.android;
 
-import io.netty.buffer.ByteBuf;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import net.tomp2p.futures.FutureDone;
-import net.tomp2p.message.Buffer;
 import net.tomp2p.message.Message;
 import net.tomp2p.message.Message.Type;
 import net.tomp2p.p2p.Peer;
 import net.tomp2p.peers.PeerAddress;
 import net.tomp2p.relay.RelayType;
-import net.tomp2p.relay.RelayUtils;
 import net.tomp2p.relay.android.gcm.FutureGCM;
 import net.tomp2p.relay.android.gcm.IGCMSender;
 import net.tomp2p.relay.android.gcm.RemoteGCMSender;
@@ -40,9 +33,6 @@ public class AndroidRelayServer extends BufferedRelayServer {
 	private final int mapUpdateIntervalMS;
 	private final AtomicLong lastUpdate;
 
-	// holds the current requests
-	private List<FutureGCM> pendingRequests;
-
 	public AndroidRelayServer(Peer peer, PeerAddress unreachablePeer, MessageBufferConfiguration bufferConfig,
 			String registrationId, IGCMSender sender, int mapUpdateIntervalS) {
 		super(peer, unreachablePeer, RelayType.ANDROID, bufferConfig);
@@ -52,8 +42,6 @@ public class AndroidRelayServer extends BufferedRelayServer {
 		// stretch the update interval by factor 1.5 to be tolerant for slow messages
 		this.mapUpdateIntervalMS = (int) (mapUpdateIntervalS * 1000 * 1.5);
 		this.lastUpdate = new AtomicLong(System.currentTimeMillis());
-
-		this.pendingRequests = Collections.synchronizedList(new ArrayList<FutureGCM>());
 	}
 
 	@Override
@@ -76,51 +64,14 @@ public class AndroidRelayServer extends BufferedRelayServer {
 	}
 
 	@Override
-	public void bufferFull(List<Message> messages) {
-		final FutureGCM futureGCM = new FutureGCM(messages, registrationId, relayPeerId());
-		synchronized (pendingRequests) {
-			pendingRequests.add(futureGCM);
-		}
-
-		sender.send(futureGCM);
+	public void onBufferFull() {
+		sender.send(new FutureGCM(registrationId, relayPeerId(), unreachablePeerAddress()));
 	}
 
 	@Override
-	public void bufferFlushed(List<Message> messages) {
-		// only adds to the buffer list, but no GCM message will be sent
-		final FutureGCM futureGCM = new FutureGCM(messages, registrationId, relayPeerId());
-		synchronized (pendingRequests) {
-			pendingRequests.add(futureGCM);
-		}
-	}
-
-	@Override
-	public Buffer collectBufferedMessages() {
+	protected void onBufferCollected() {
 		// the mobile device seems to be alive
 		lastUpdate.set(System.currentTimeMillis());
-
-		// flush the current buffer to get all messages
-		buffer.flushNow();
-
-		List<Message> messages = new ArrayList<Message>();
-		synchronized (pendingRequests) {
-			for (FutureGCM futureGCM : pendingRequests) {
-				messages.addAll(futureGCM.buffer());
-				futureGCM.done();
-			}
-
-			pendingRequests.clear();
-		}
-
-		if (messages.isEmpty()) {
-			LOG.trace("Currently there are no buffered messages");
-			return null;
-		}
-
-		ByteBuf byteBuffer = RelayUtils.composeMessageBuffer(messages, connectionBean().channelServer()
-				.channelServerConfiguration().signatureFactory());
-		LOG.debug("Buffer of {} messages collected", messages.size());
-		return new Buffer(byteBuffer);
 	}
 
 	@Override
@@ -128,7 +79,7 @@ public class AndroidRelayServer extends BufferedRelayServer {
 		// take this event as an indicator that the mobile device is online
 		lastUpdate.set(System.currentTimeMillis());
 		LOG.trace("Timeout for {} refreshed", registrationId);
-		
+
 		if (requestMessage.neighborsSet(1) != null && sender instanceof RemoteGCMSender) {
 			// update the GCM servers
 			RemoteGCMSender remoteGCMSender = (RemoteGCMSender) sender;
@@ -151,4 +102,5 @@ public class AndroidRelayServer extends BufferedRelayServer {
 			return false;
 		}
 	}
+
 }

--- a/android/src/main/java/net/tomp2p/relay/android/AndroidRelayServerConfig.java
+++ b/android/src/main/java/net/tomp2p/relay/android/AndroidRelayServerConfig.java
@@ -22,10 +22,10 @@ import org.slf4j.LoggerFactory;
 public class AndroidRelayServerConfig extends RelayServerConfig {
 
 	private static final Logger LOG = LoggerFactory.getLogger(AndroidRelayServerConfig.class);
-	private static final int DEFAULT_GCM_RETRIES = 5;
 
 	private final MessageBufferConfiguration bufferConfig;
 	private final String gcmAuthenticationKey;
+	private final int gcmRetries;
 	protected IGCMSender gcmSender;
 
 	/**
@@ -33,10 +33,12 @@ public class AndroidRelayServerConfig extends RelayServerConfig {
 	 * 
 	 * @param gcmAuthenticationKey the api key / authentication token for Google Cloud Messaging. The key
 	 *            can be obtained through Google's developer console. The key should be kept secret.
+	 * @param gcmRetries how many times the GCM message should be resent before giving up. Normal ranges are 1-5
 	 * @param bufferConfig the buffer behavior before sending a GCM message to the Android device
 	 */
-	public AndroidRelayServerConfig(String gcmAuthenticationKey, MessageBufferConfiguration bufferConfig) {
+	public AndroidRelayServerConfig(String gcmAuthenticationKey, int gcmRetries, MessageBufferConfiguration bufferConfig) {
 		this.gcmAuthenticationKey = gcmAuthenticationKey;
+		this.gcmRetries = gcmRetries;
 		this.bufferConfig = bufferConfig;
 	}
 
@@ -49,13 +51,13 @@ public class AndroidRelayServerConfig extends RelayServerConfig {
 	 *            {@link RemoteGCMSender}).
 	 */
 	public AndroidRelayServerConfig(MessageBufferConfiguration bufferConfig) {
-		this(null, bufferConfig);
+		this(null, 0, bufferConfig);
 	}
 
 	@Override
 	public void start(Peer peer) {
 		if (gcmAuthenticationKey != null) {
-			gcmSender = new GCMSenderRPC(peer, gcmAuthenticationKey, DEFAULT_GCM_RETRIES);
+			gcmSender = new GCMSenderRPC(peer, gcmAuthenticationKey, gcmRetries);
 			LOG.debug("GCM server started on {}", peer.peerAddress());
 		}
 	}

--- a/android/src/main/java/net/tomp2p/relay/android/gcm/FutureGCM.java
+++ b/android/src/main/java/net/tomp2p/relay/android/gcm/FutureGCM.java
@@ -1,29 +1,20 @@
 package net.tomp2p.relay.android.gcm;
 
-import java.util.List;
-
 import net.tomp2p.futures.FutureDone;
-import net.tomp2p.message.Message;
 import net.tomp2p.peers.Number160;
+import net.tomp2p.peers.PeerAddress;
 
 public class FutureGCM extends FutureDone<Void> {
 
-	private final List<Message> buffer;
 	private final String registrationId;
 	private final Number160 senderId;
+	private final PeerAddress recipient;
 
-	public FutureGCM(List<Message> buffer, String registrationId, Number160 senderId) {
+	public FutureGCM(String registrationId, Number160 senderId, PeerAddress recipient) {
 		self(this);
 		this.registrationId = registrationId;
 		this.senderId = senderId;
-		this.buffer = buffer;
-	}
-
-	/**
-	 * The buffered messages (not sent over GCM)
-	 */
-	public List<Message> buffer() {
-		return buffer;
+		this.recipient = recipient;
 	}
 
 	/**
@@ -38,5 +29,12 @@ public class FutureGCM extends FutureDone<Void> {
 	 */
 	public Number160 senderId() {
 		return senderId;
+	}
+
+	/**
+	 * The unreachable peer receiving the GCM
+	 */
+	public PeerAddress recipient() {
+		return recipient;
 	}
 }

--- a/android/src/main/java/net/tomp2p/relay/android/gcm/GCMSenderRPC.java
+++ b/android/src/main/java/net/tomp2p/relay/android/gcm/GCMSenderRPC.java
@@ -85,7 +85,7 @@ public class GCMSenderRPC extends DispatchHandler implements IGCMSender {
 			return;
 		}
 		
-		FutureGCM futureGCM = new FutureGCM(null, registrationId, message.sender().peerId());
+		FutureGCM futureGCM = new FutureGCM(registrationId, message.sender().peerId(), message.recipient());
 		send(futureGCM);
 		futureGCM.addListener(new BaseFutureAdapter<FutureGCM>() {
 

--- a/android/src/test/java/net/tomp2p/relay/android/MockedGCMSender.java
+++ b/android/src/test/java/net/tomp2p/relay/android/MockedGCMSender.java
@@ -33,7 +33,7 @@ public class MockedGCMSender extends GCMSenderRPC implements IGCMSender {
 				} catch (InterruptedException e) {
 					// ignore
 				}
-				PeerAddress recipient = futureGCM.buffer().get(0).recipient();
+				PeerAddress recipient = futureGCM.recipient();
 				client.mockGCMNotification(recipient);
 				LOG.debug("Mocked sending a message to the unreachable peer {}", recipient);
 			}

--- a/nat/src/main/java/net/tomp2p/relay/PeerMapUpdateTask.java
+++ b/nat/src/main/java/net/tomp2p/relay/PeerMapUpdateTask.java
@@ -64,7 +64,7 @@ public class PeerMapUpdateTask extends TimerTask {
 
 		// send the peer map to the relays
 		List<Map<Number160, PeerStatistic>> peerMapVerified = relayRPC.peer().peerBean().peerMap().peerMapVerified();
-		for (final BaseRelayClient relay : distributedRelay.relays()) {
+		for (final BaseRelayClient relay : distributedRelay.relayClients()) {
 			sendPeerMap(relay, peerMapVerified);
 		}
 

--- a/nat/src/main/java/net/tomp2p/relay/RelayType.java
+++ b/nat/src/main/java/net/tomp2p/relay/RelayType.java
@@ -8,9 +8,14 @@ public enum RelayType {
 	OPENTCP(true, 5, false),
 
 	/**
-	 * Data exchange will take place over Google Cloud Messaging
+	 * Data exchange will take place over Google Cloud Messaging. The server buffers multiple requests.
 	 */
-	ANDROID(false, 4, true);
+	ANDROID(false, 4, true),
+	
+	/**
+	 * Same as {@link #OPENTCP}, but the server buffers messages and sends them in bulk.
+	 */
+	BUFFERED_OPENTCP(true, 5, true);
 
 	private final boolean keepConnectionOpen;
 	private final int maxRelayCount;

--- a/nat/src/main/java/net/tomp2p/relay/buffer/BufferRequestListener.java
+++ b/nat/src/main/java/net/tomp2p/relay/buffer/BufferRequestListener.java
@@ -1,5 +1,7 @@
 package net.tomp2p.relay.buffer;
 
+import net.tomp2p.futures.FutureDone;
+
 public interface BufferRequestListener {
 
 	/**
@@ -7,5 +9,5 @@ public interface BufferRequestListener {
 	 * 
 	 * @param relayPeerId the relay's peer id
 	 */
-	void sendBufferRequest(String relayPeerId);
+	FutureDone<Void> sendBufferRequest(String relayPeerId);
 }

--- a/nat/src/main/java/net/tomp2p/relay/buffer/BufferedRelayServer.java
+++ b/nat/src/main/java/net/tomp2p/relay/buffer/BufferedRelayServer.java
@@ -1,8 +1,13 @@
 package net.tomp2p.relay.buffer;
 
+import io.netty.buffer.ByteBuf;
+
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.SignatureException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import net.tomp2p.message.Buffer;
 import net.tomp2p.message.Message;
@@ -12,16 +17,27 @@ import net.tomp2p.relay.BaseRelayServer;
 import net.tomp2p.relay.RelayType;
 import net.tomp2p.relay.RelayUtils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public abstract class BufferedRelayServer extends BaseRelayServer implements MessageBufferListener<Message> {
 
-	protected final MessageBuffer<Message> buffer;
+	private static final Logger LOG = LoggerFactory.getLogger(BufferedRelayServer.class);
+
+	private final MessageBuffer<Message> buffer;
 	private final MessageBufferConfiguration bufferConfig;
+
+	// holds the messages that have already been released from the buffer (because any limit has been
+	// triggered or the buffer has been flushed)
+	private final List<Message> bufferedMessages;
 
 	protected BufferedRelayServer(Peer peer, PeerAddress unreachablePeer, RelayType relayType,
 			MessageBufferConfiguration bufferConfig) {
 		super(peer, unreachablePeer, relayType);
 		this.bufferConfig = bufferConfig;
-		buffer = new MessageBuffer<Message>(bufferConfig);
+		this.buffer = new MessageBuffer<Message>(bufferConfig);
+		this.bufferedMessages = Collections.synchronizedList(new ArrayList<Message>());
+
 		buffer.addListener(this);
 	}
 
@@ -34,6 +50,28 @@ public abstract class BufferedRelayServer extends BaseRelayServer implements Mes
 		buffer.addMessage(message, messageSize);
 	}
 
+	@Override
+	public void bufferFull(List<Message> messages) {
+		synchronized (bufferedMessages) {
+			bufferedMessages.addAll(messages);
+		}
+
+		onBufferFull();
+	}
+
+	/**
+	 * Called when the buffer is full and has been triggered. The messages in the buffer are kept in
+	 * {@link BufferedRelayServer}.
+	 */
+	public abstract void onBufferFull();
+
+	@Override
+	public void bufferFlushed(List<Message> messages) {
+		synchronized (bufferedMessages) {
+			bufferedMessages.addAll(messages);
+		}
+	}
+
 	/**
 	 * Retrieves the messages that are ready to send. Ready to send means that they have been buffered and the
 	 * Android device has already been notified.
@@ -41,7 +79,31 @@ public abstract class BufferedRelayServer extends BaseRelayServer implements Mes
 	 * @return the buffer containing all buffered messages or <code>null</code> in case no message has been
 	 *         buffered
 	 */
-	public abstract Buffer collectBufferedMessages();
+	public Buffer collectBufferedMessages() {
+		// flush the current buffer to get all messages
+		buffer.flushNow();
+
+		Buffer buffer = null;;
+		synchronized (bufferedMessages) {
+			if (bufferedMessages.isEmpty()) {
+				LOG.trace("Currently there are no buffered messages");
+			} else {
+				ByteBuf byteBuffer = RelayUtils.composeMessageBuffer(bufferedMessages, connectionBean().channelServer()
+						.channelServerConfiguration().signatureFactory());
+				LOG.debug("Buffer of {} messages collected", bufferedMessages.size());
+				bufferedMessages.clear();
+				buffer = new Buffer(byteBuffer);
+			}
+		}
+
+		onBufferCollected();
+		return buffer;
+	}
+
+	/**
+	 * Called when the buffer has been collected by the unreachable peer
+	 */
+	protected abstract void onBufferCollected();
 
 	@Override
 	protected void peerMapUpdated(Message originalMessage, Message preparedResponse) {

--- a/nat/src/main/java/net/tomp2p/relay/tcp/buffered/BufferedTCPRelayClient.java
+++ b/nat/src/main/java/net/tomp2p/relay/tcp/buffered/BufferedTCPRelayClient.java
@@ -1,0 +1,46 @@
+package net.tomp2p.relay.tcp.buffered;
+
+import net.tomp2p.connection.PeerConnection;
+import net.tomp2p.futures.FutureDone;
+import net.tomp2p.futures.FutureResponse;
+import net.tomp2p.message.Message;
+import net.tomp2p.p2p.Peer;
+import net.tomp2p.relay.buffer.BufferedRelayClient;
+import net.tomp2p.relay.tcp.TCPRelayClient;
+
+public class BufferedTCPRelayClient extends BufferedRelayClient {
+
+	private final TCPRelayClient tcpRelayClient;
+
+	public BufferedTCPRelayClient(PeerConnection connection, Peer peer) {
+		super(connection.remotePeer(), peer);
+		tcpRelayClient = new TCPRelayClient(connection, peer);
+	}
+
+	@Override
+	public FutureDone<Void> sendBufferRequest() {
+		// nothing to do because the buffer is sent automatically
+		return new FutureDone<Void>().done();
+	}
+
+	@Override
+	public FutureResponse sendToRelay(Message message) {
+		return tcpRelayClient.sendToRelay(message);
+	}
+
+	@Override
+	public FutureDone<Void> shutdown() {
+		return tcpRelayClient.shutdown();
+	}
+
+	@Override
+	public void onMapUpdateSuccess() {
+		// nothing to do
+	}
+
+	@Override
+	public void onMapUpdateFailed() {
+		// nothing to do
+	}
+
+}

--- a/nat/src/main/java/net/tomp2p/relay/tcp/buffered/BufferedTCPRelayClient.java
+++ b/nat/src/main/java/net/tomp2p/relay/tcp/buffered/BufferedTCPRelayClient.java
@@ -5,9 +5,18 @@ import net.tomp2p.futures.FutureDone;
 import net.tomp2p.futures.FutureResponse;
 import net.tomp2p.message.Message;
 import net.tomp2p.p2p.Peer;
+import net.tomp2p.relay.RelayRPC;
 import net.tomp2p.relay.buffer.BufferedRelayClient;
 import net.tomp2p.relay.tcp.TCPRelayClient;
 
+/**
+ * Basically the same implementation as {@link TCPRelayClient}, but exending from the
+ * {@link BufferedRelayClient} such that the {@link RelayRPC} can distinguish between buffered and unbuffered
+ * connections.
+ * 
+ * @author Nico Rutishauser
+ *
+ */
 public class BufferedTCPRelayClient extends BufferedRelayClient {
 
 	private final TCPRelayClient tcpRelayClient;

--- a/nat/src/main/java/net/tomp2p/relay/tcp/buffered/BufferedTCPRelayClientConfig.java
+++ b/nat/src/main/java/net/tomp2p/relay/tcp/buffered/BufferedTCPRelayClientConfig.java
@@ -1,0 +1,31 @@
+package net.tomp2p.relay.tcp.buffered;
+
+import net.tomp2p.connection.PeerConnection;
+import net.tomp2p.message.Message;
+import net.tomp2p.p2p.Peer;
+import net.tomp2p.relay.BaseRelayClient;
+import net.tomp2p.relay.RelayClientConfig;
+import net.tomp2p.relay.RelayType;
+
+public class BufferedTCPRelayClientConfig extends RelayClientConfig {
+
+	public BufferedTCPRelayClientConfig() {
+		super(RelayType.BUFFERED_OPENTCP, 15, 60, 2);
+	}
+
+	@Override
+	public BaseRelayClient createClient(PeerConnection connection, Peer peer) {
+		return new BufferedTCPRelayClient(connection, peer);
+	}
+
+	@Override
+	public void prepareSetupMessage(Message message) {
+		// nothing to attach
+	}
+
+	@Override
+	public void prepareMapUpdateMessage(Message message) {
+		// nothing to attach
+	}
+
+}

--- a/nat/src/main/java/net/tomp2p/relay/tcp/buffered/BufferedTCPRelayServer.java
+++ b/nat/src/main/java/net/tomp2p/relay/tcp/buffered/BufferedTCPRelayServer.java
@@ -1,0 +1,54 @@
+package net.tomp2p.relay.tcp.buffered;
+
+import net.tomp2p.connection.PeerConnection;
+import net.tomp2p.futures.BaseFutureAdapter;
+import net.tomp2p.futures.FutureDone;
+import net.tomp2p.message.Buffer;
+import net.tomp2p.message.Message;
+import net.tomp2p.message.Message.Type;
+import net.tomp2p.p2p.Peer;
+import net.tomp2p.relay.RelayType;
+import net.tomp2p.relay.buffer.BufferedRelayServer;
+import net.tomp2p.relay.buffer.MessageBufferConfiguration;
+import net.tomp2p.relay.tcp.TCPRelayServer;
+import net.tomp2p.rpc.RPC.Commands;
+
+public class BufferedTCPRelayServer extends BufferedRelayServer {
+
+	private final PeerConnection connection;
+	private final TCPRelayServer tcpRelayServer;
+
+	protected BufferedTCPRelayServer(PeerConnection connection, Peer peer, MessageBufferConfiguration bufferConfig) {
+		super(peer, connection.remotePeer(), RelayType.BUFFERED_OPENTCP, bufferConfig);
+		this.connection = connection;
+		this.tcpRelayServer = new TCPRelayServer(connection, peer);
+
+		// add a listener when the connection is closed
+		connection.closeFuture().addListener(new BaseFutureAdapter<FutureDone<Void>>() {
+			@Override
+			public void operationComplete(FutureDone<Void> future) throws Exception {
+				notifyOfflineListeners();
+			}
+		});
+	}
+
+	@Override
+	public void onBufferFull() {
+		Buffer messages = collectBufferedMessages();
+		Message message = createMessage(connection.remotePeer(), Commands.RELAY.getNr(), Type.REQUEST_4);
+		message.buffer(messages);
+
+		tcpRelayServer.forwardToUnreachable(message);
+	}
+
+	@Override
+	protected void onBufferCollected() {
+		// ignore
+	}
+
+	@Override
+	protected boolean isAlive() {
+		return connection.isOpen();
+	}
+
+}

--- a/nat/src/main/java/net/tomp2p/relay/tcp/buffered/BufferedTCPRelayServer.java
+++ b/nat/src/main/java/net/tomp2p/relay/tcp/buffered/BufferedTCPRelayServer.java
@@ -13,6 +13,13 @@ import net.tomp2p.relay.buffer.MessageBufferConfiguration;
 import net.tomp2p.relay.tcp.TCPRelayServer;
 import net.tomp2p.rpc.RPC.Commands;
 
+/**
+ * The buffered TCP server acts similar to the normal {@link TCPRelayServer}, but instead of sending messages
+ * immediately to the unreachable peer, messages are buffered for a certain time.
+ * 
+ * @author Nico Rutishauser
+ *
+ */
 public class BufferedTCPRelayServer extends BufferedRelayServer {
 
 	private final PeerConnection connection;

--- a/nat/src/main/java/net/tomp2p/relay/tcp/buffered/BufferedTCPRelayServerConfig.java
+++ b/nat/src/main/java/net/tomp2p/relay/tcp/buffered/BufferedTCPRelayServerConfig.java
@@ -1,0 +1,43 @@
+package net.tomp2p.relay.tcp.buffered;
+
+import net.tomp2p.connection.PeerConnection;
+import net.tomp2p.connection.Responder;
+import net.tomp2p.message.Message;
+import net.tomp2p.message.Message.Type;
+import net.tomp2p.p2p.Peer;
+import net.tomp2p.relay.BaseRelayServer;
+import net.tomp2p.relay.RelayServerConfig;
+import net.tomp2p.relay.buffer.MessageBufferConfiguration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BufferedTCPRelayServerConfig extends RelayServerConfig {
+
+	private final static Logger LOG = LoggerFactory.getLogger(BufferedTCPRelayServerConfig.class);
+	private final MessageBufferConfiguration bufferConfig;
+
+	public BufferedTCPRelayServerConfig(MessageBufferConfiguration bufferConfig) {
+		this.bufferConfig = bufferConfig;
+	}
+	
+	@Override
+	public void start(Peer peer) {
+		// nothing to do
+	}
+	
+	@Override
+	public BaseRelayServer createServer(Message message, PeerConnection peerConnection, Responder responder, Peer peer) {
+		if (peer.peerAddress().isRelayed()) {
+			// peer is behind a NAT as well -> deny request
+			LOG.warn("I cannot be a relay since I'm relayed as well! {}", message);
+			responder.response(createResponse(message, Type.DENIED, peer.peerBean().serverPeerAddress()));
+			return null;
+		}
+
+		LOG.debug("Hello unreachable peer! You'll be relayed over a buffered open TCP connection.");
+		BufferedTCPRelayServer tcpForwarder = new BufferedTCPRelayServer(peerConnection, peer, bufferConfig);
+		responder.response(createResponse(message, Type.OK, peer.peerBean().serverPeerAddress()));
+		return tcpForwarder;
+	}
+}

--- a/nat/src/test/java/net/tomp2p/relay/TestRelay.java
+++ b/nat/src/test/java/net/tomp2p/relay/TestRelay.java
@@ -101,7 +101,6 @@ public class TestRelay {
 			PeerNAT uNat = new PeerBuilderNAT(unreachablePeer).start();
 			FutureRelayNAT startRelay = uNat.startRelay(clientConfig, peers[0].peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(startRelay.isSuccess());
-			// mockGCM(peers, uNat, startRelay.gcmMessageHandler());
 
 			// Check if flags are set correctly
 			Assert.assertTrue(unreachablePeer.peerAddress().isRelayed());
@@ -147,7 +146,6 @@ public class TestRelay {
 			PeerNAT uNat = new PeerBuilderNAT(unreachablePeer).start();
 			FutureRelayNAT startRelay = uNat.startRelay(clientConfig, peers[0].peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(startRelay.isSuccess());
-			// mockGCM(peers, uNat, startRelay.gcmMessageHandler());
 
 			// find neighbors again
 			futureBootstrap = unreachablePeer.bootstrap().peerAddress(peers[0].peerAddress()).start();
@@ -219,7 +217,6 @@ public class TestRelay {
 			FutureRelayNAT fbn = uNat1.startRelay(clientConfig, master.peerAddress());
 			fbn.awaitUninterruptibly();
 			Assert.assertTrue(fbn.isSuccess());
-			// mockGCM(peers, uNat1, fbn.gcmMessageHandler());
 
 			System.out.print("Send direct message to unreachable peer " + unreachablePeer1.peerAddress());
 			final String request = "Hello ";
@@ -251,7 +248,6 @@ public class TestRelay {
 
 			fbn.awaitUninterruptibly();
 			Assert.assertTrue(fbn.isSuccess());
-			// mockGCM(peers, uNat2, fbn.gcmMessageHandler());
 
 			// prevent rcon
 			Collection<PeerSocketAddress> list = unreachablePeer2.peerBean().serverPeerAddress().peerSocketAddresses();
@@ -318,7 +314,6 @@ public class TestRelay {
 			PeerNAT uNat = new PeerBuilderNAT(unreachablePeer).start();
 			FutureRelayNAT startRelay = uNat.startRelay(clientConfig, peers[0].peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(startRelay.isSuccess());
-			// mockGCM(peers, uNat, startRelay.gcmMessageHandler());
 
 			System.out.print("Send direct message to unreachable peer");
 			final String request = "Hello ";
@@ -371,7 +366,6 @@ public class TestRelay {
 			PeerNAT uNat = new PeerBuilderNAT(unreachablePeer).start();
 			FutureRelayNAT startRelay = uNat.startRelay(clientConfig, peers[0].peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(startRelay.isSuccess());
-			// mockGCM(peers, uNat, startRelay.gcmMessageHandler());
 
 			System.out.print("Send direct message from unreachable peer");
 			final String request = "Hello ";
@@ -432,7 +426,6 @@ public class TestRelay {
 			FutureRelayNAT startRelay = uNat.startRelay(clientConfig, peers[0].peerAddress());
 			FutureRelay frNAT = startRelay.awaitUninterruptibly().futureRelay();
 			Assert.assertTrue(startRelay.isSuccess());
-			// mockGCM(peers, uNat, startRelay.gcmMessageHandler());
 
 			PeerAddress relayPeer = frNAT.relays().iterator().next().relayAddress();
 			Peer found = null;
@@ -543,7 +536,6 @@ public class TestRelay {
 					.start();
 			PeerNAT uNat = new PeerBuilderNAT(unreachablePeer.peer()).start();
 			uNat.startRelay(clientConfig, master.peerAddress());
-			// mockGCM(peers, uNat, startRelay.gcmMessageHandler());
 
 			FutureRelayNAT fbn = uNat.startRelay(clientConfig, master.peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(fbn.isSuccess());
@@ -580,7 +572,6 @@ public class TestRelay {
 
 			FutureRelayNAT fbn = uNat.startRelay(clientConfig, master.peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(fbn.isSuccess());
-			// mockGCM(peers, uNat, fbn.gcmMessageHandler());
 
 			// wait for maintenance to kick in
 			waitMapUpdate();
@@ -632,7 +623,6 @@ public class TestRelay {
 			unreachablePeer.peer().bootstrap().peerAddress(master.peerAddress()).start();
 			FutureRelayNAT fbn = uNat.startRelay(clientConfig, master.peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(fbn.isSuccess());
-			// mockGCM(peers, uNat, fbn.gcmMessageHandler());
 
 			// wait for maintenance to kick in
 			waitMapUpdate();
@@ -703,10 +693,6 @@ public class TestRelay {
 
 			// wait for relay setup
 			Thread.sleep(5000);
-
-			// mockGCM(peers, uNat1, fbn1.gcmMessageHandler());
-			// mockGCM(peers, uNat2, fbn2.gcmMessageHandler());
-			UtilsNAT.perfectRouting(peers);
 
 			// wait for maintenance to kick in
 			waitMapUpdate();
@@ -791,10 +777,6 @@ public class TestRelay {
 
 			// wait for relay setup
 			Thread.sleep(5000);
-
-			// mockGCM(peers, uNat1, fbn1.gcmMessageHandler());
-			// mockGCM(peers, uNat2, fbn2.gcmMessageHandler());
-			UtilsNAT.perfectRouting(peers);
 
 			// wait for maintenance to kick in
 			waitMapUpdate();

--- a/nat/src/test/java/net/tomp2p/relay/TestRelay.java
+++ b/nat/src/test/java/net/tomp2p/relay/TestRelay.java
@@ -31,8 +31,11 @@ import net.tomp2p.peers.PeerAddress;
 import net.tomp2p.peers.PeerMap;
 import net.tomp2p.peers.PeerMapConfiguration;
 import net.tomp2p.peers.PeerSocketAddress;
+import net.tomp2p.relay.buffer.MessageBufferConfiguration;
 import net.tomp2p.relay.tcp.TCPRelayClientConfig;
 import net.tomp2p.relay.tcp.TCPRelayServerConfig;
+import net.tomp2p.relay.tcp.buffered.BufferedTCPRelayClientConfig;
+import net.tomp2p.relay.tcp.buffered.BufferedTCPRelayServerConfig;
 import net.tomp2p.rpc.DispatchHandler;
 import net.tomp2p.rpc.ObjectDataReply;
 import net.tomp2p.storage.Data;
@@ -49,30 +52,28 @@ public class TestRelay {
 	private final RelayServerConfig serverConfig;
 	private final RelayClientConfig clientConfig;
 
-
 	@SuppressWarnings("rawtypes")
-	@Parameterized.Parameters(name = "{0}")
+	@Parameterized.Parameters
 	public static Collection data() throws Exception {
+		MessageBufferConfiguration ageLimit = new MessageBufferConfiguration().bufferAgeLimit(2000).bufferCountLimit(Integer.MAX_VALUE).bufferSizeLimit(Long.MAX_VALUE);
+		MessageBufferConfiguration singleBuf = new MessageBufferConfiguration().bufferAgeLimit(Long.MAX_VALUE).bufferCountLimit(1).bufferSizeLimit(Long.MAX_VALUE);
+		
 		return Arrays.asList(new Object[][] {
-				{ RelayType.OPENTCP, new TCPRelayServerConfig(), new TCPRelayClientConfig().peerMapUpdateInterval(5) } }
-		);
+				{ RelayType.OPENTCP, new TCPRelayServerConfig(), new TCPRelayClientConfig().peerMapUpdateInterval(5) },
+				{ RelayType.BUFFERED_OPENTCP, new BufferedTCPRelayServerConfig(ageLimit), new BufferedTCPRelayClientConfig().peerMapUpdateInterval(5) },
+				{ RelayType.BUFFERED_OPENTCP, new BufferedTCPRelayServerConfig(singleBuf), new BufferedTCPRelayClientConfig().peerMapUpdateInterval(5) } });
 	}
-	
+
 	public TestRelay(RelayType relayType, RelayServerConfig serverConfig, RelayClientConfig clientConfig) {
 		this.relayType = relayType;
 		this.serverConfig = serverConfig;
 		this.clientConfig = clientConfig;
 	}
-	
-	
+
 	private void waitMapUpdate() throws InterruptedException {
 		Thread.sleep(clientConfig.peerMapUpdateInterval() * 1000);
-//		if(serverConfig instanceof BufferedRelayServer) {
-//			BufferedRelayServer bufferedRelayServer = (BufferedRelayServer) serverConfig;
-//			Thread.sleep(bufferedRelayServer.bufferConfiguration().bufferAgeLimit());
-//		}
 	}
-	
+
 	@Test
 	public void testSetupRelayPeers() throws Exception {
 		final Random rnd = new Random(42);
@@ -100,7 +101,7 @@ public class TestRelay {
 			PeerNAT uNat = new PeerBuilderNAT(unreachablePeer).start();
 			FutureRelayNAT startRelay = uNat.startRelay(clientConfig, peers[0].peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(startRelay.isSuccess());
-//			mockGCM(peers, uNat, startRelay.gcmMessageHandler());
+			// mockGCM(peers, uNat, startRelay.gcmMessageHandler());
 
 			// Check if flags are set correctly
 			Assert.assertTrue(unreachablePeer.peerAddress().isRelayed());
@@ -146,7 +147,7 @@ public class TestRelay {
 			PeerNAT uNat = new PeerBuilderNAT(unreachablePeer).start();
 			FutureRelayNAT startRelay = uNat.startRelay(clientConfig, peers[0].peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(startRelay.isSuccess());
-//			mockGCM(peers, uNat, startRelay.gcmMessageHandler());
+			// mockGCM(peers, uNat, startRelay.gcmMessageHandler());
 
 			// find neighbors again
 			futureBootstrap = unreachablePeer.bootstrap().peerAddress(peers[0].peerAddress()).start();
@@ -218,67 +219,69 @@ public class TestRelay {
 			FutureRelayNAT fbn = uNat1.startRelay(clientConfig, master.peerAddress());
 			fbn.awaitUninterruptibly();
 			Assert.assertTrue(fbn.isSuccess());
-//			mockGCM(peers, uNat1, fbn.gcmMessageHandler());
+			// mockGCM(peers, uNat1, fbn.gcmMessageHandler());
 
-         	System.out.print("Send direct message to unreachable peer " + unreachablePeer1.peerAddress());
-            final String request = "Hello ";
-            final String response = "World!";
-            
-            final AtomicBoolean test1 = new AtomicBoolean(false);
-            final AtomicBoolean test2 = new AtomicBoolean(false);
-            
-            //final Peer unr = unreachablePeer;
-            unreachablePeer1.objectDataReply(new ObjectDataReply() {
-                public Object reply(PeerAddress sender, Object obj) throws Exception {
-                	test1.set(obj.equals(request));
-                    Assert.assertEquals(request.toString(), request);
-                    test2.set(sender.inetAddress().toString().contains("0.0.0.0"));
-                    System.err.println("Got sender:"+sender);
-                    
-                    //this is too late here, so we cannot test this here
-                    //Collection<PeerSocketAddress> list = new ArrayList<PeerSocketAddress>();
-                    //list.add(new PeerSocketAddress(InetAddress.getByName("101.101.101.101"), 101, 101));
-                    //unr.peerBean().serverPeerAddress(unr.peerBean().serverPeerAddress().changePeerSocketAddresses(list));
-                    
-                    return response;
-                }
-            });
-            
-            
-            unreachablePeer2 = new PeerBuilder(Number160.createHash(rnd.nextInt())).ports(13338).start();
+			System.out.print("Send direct message to unreachable peer " + unreachablePeer1.peerAddress());
+			final String request = "Hello ";
+			final String response = "World!";
+
+			final AtomicBoolean test1 = new AtomicBoolean(false);
+			final AtomicBoolean test2 = new AtomicBoolean(false);
+
+			// final Peer unr = unreachablePeer;
+			unreachablePeer1.objectDataReply(new ObjectDataReply() {
+				public Object reply(PeerAddress sender, Object obj) throws Exception {
+					test1.set(obj.equals(request));
+					Assert.assertEquals(request.toString(), request);
+					test2.set(sender.inetAddress().toString().contains("0.0.0.0"));
+					System.err.println("Got sender:" + sender);
+
+					// this is too late here, so we cannot test this here
+					// Collection<PeerSocketAddress> list = new ArrayList<PeerSocketAddress>();
+					// list.add(new PeerSocketAddress(InetAddress.getByName("101.101.101.101"), 101, 101));
+					// unr.peerBean().serverPeerAddress(unr.peerBean().serverPeerAddress().changePeerSocketAddresses(list));
+
+					return response;
+				}
+			});
+
+			unreachablePeer2 = new PeerBuilder(Number160.createHash(rnd.nextInt())).ports(13338).start();
 			PeerNAT uNat2 = new PeerBuilderNAT(unreachablePeer2).start();
 			fbn = uNat2.startRelay(clientConfig, peers[42].peerAddress());
-			
+
 			fbn.awaitUninterruptibly();
 			Assert.assertTrue(fbn.isSuccess());
-//			mockGCM(peers, uNat2, fbn.gcmMessageHandler());
+			// mockGCM(peers, uNat2, fbn.gcmMessageHandler());
 
-			//prevent rcon
+			// prevent rcon
 			Collection<PeerSocketAddress> list = unreachablePeer2.peerBean().serverPeerAddress().peerSocketAddresses();
-			if(list.size() >= clientConfig.type().maxRelayCount()) {
+			if (list.size() >= clientConfig.type().maxRelayCount()) {
 				Iterator<PeerSocketAddress> iterator = list.iterator();
 				iterator.next();
 				iterator.remove();
 			}
 			list.add(new PeerSocketAddress(InetAddress.getByName("10.10.10.10"), 10, 10));
-			unreachablePeer2.peerBean().serverPeerAddress(unreachablePeer2.peerBean().serverPeerAddress().changePeerSocketAddresses(list));
-            
+			unreachablePeer2.peerBean().serverPeerAddress(
+					unreachablePeer2.peerBean().serverPeerAddress().changePeerSocketAddresses(list));
+
 			System.err.println("unreachablePeer1: " + unreachablePeer1.peerAddress());
-			System.err.println("unreachablePeer2: "+unreachablePeer2.peerAddress());
-			
-            FutureDirect fd = unreachablePeer2.sendDirect(unreachablePeer1.peerAddress()).object(request).start().awaitUninterruptibly();
-            System.err.println("got msg from: "+fd.futureResponse().responseMessage().sender());
-            Assert.assertEquals(response, fd.object());
-            //make sure we did not receive it from the unreachable peer with port 13337
-            //System.err.println(fd.getWrappedFuture());
-            //TODO: this case is true for relay
-            //Assert.assertEquals(fd.wrappedFuture().responseMessage().senderSocket().getPort(), 4001);
-            //TODO: this case is true for rcon
-            Assert.assertEquals(unreachablePeer1.peerID(), fd.wrappedFuture().responseMessage().sender().peerId());
-            
-            Assert.assertTrue(test1.get());
-            Assert.assertFalse(test2.get());
-            Assert.assertEquals(clientConfig.type().maxRelayCount(), fd.futureResponse().responseMessage().sender().peerSocketAddresses().size());
+			System.err.println("unreachablePeer2: " + unreachablePeer2.peerAddress());
+
+			FutureDirect fd = unreachablePeer2.sendDirect(unreachablePeer1.peerAddress()).object(request).start()
+					.awaitUninterruptibly();
+			System.err.println("got msg from: " + fd.futureResponse().responseMessage().sender());
+			Assert.assertEquals(response, fd.object());
+			// make sure we did not receive it from the unreachable peer with port 13337
+			// System.err.println(fd.getWrappedFuture());
+			// TODO: this case is true for relay
+			// Assert.assertEquals(fd.wrappedFuture().responseMessage().senderSocket().getPort(), 4001);
+			// TODO: this case is true for rcon
+			Assert.assertEquals(unreachablePeer1.peerID(), fd.wrappedFuture().responseMessage().sender().peerId());
+
+			Assert.assertTrue(test1.get());
+			Assert.assertFalse(test2.get());
+			Assert.assertEquals(clientConfig.type().maxRelayCount(), fd.futureResponse().responseMessage().sender()
+					.peerSocketAddresses().size());
 		} finally {
 			if (unreachablePeer1 != null) {
 				unreachablePeer1.shutdown().await();
@@ -291,7 +294,7 @@ public class TestRelay {
 			}
 		}
 	}
-	
+
 	/**
 	 * Tests sending a message from a reachable peer to an unreachable peer
 	 */
@@ -315,7 +318,7 @@ public class TestRelay {
 			PeerNAT uNat = new PeerBuilderNAT(unreachablePeer).start();
 			FutureRelayNAT startRelay = uNat.startRelay(clientConfig, peers[0].peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(startRelay.isSuccess());
-//			mockGCM(peers, uNat, startRelay.gcmMessageHandler());
+			// mockGCM(peers, uNat, startRelay.gcmMessageHandler());
 
 			System.out.print("Send direct message to unreachable peer");
 			final String request = "Hello ";
@@ -332,7 +335,7 @@ public class TestRelay {
 					.awaitUninterruptibly();
 			Assert.assertTrue(fd.isSuccess());
 			Assert.assertEquals(response, fd.object());
-			
+
 			// make sure we did receive it from the unreachable peer with id
 			Assert.assertEquals(unreachablePeer.peerID(), fd.wrappedFuture().responseMessage().sender().peerId());
 		} finally {
@@ -344,7 +347,7 @@ public class TestRelay {
 			}
 		}
 	}
-	
+
 	/**
 	 * Tests sending a message from an unreachable peer to a reachable peer
 	 */
@@ -362,13 +365,13 @@ public class TestRelay {
 			for (Peer peer : peers) {
 				new PeerBuilderNAT(peer).addRelayServerConfiguration(relayType, serverConfig).start();
 			}
-			
+
 			// setup relay
 			unreachablePeer = new PeerBuilder(Number160.createHash(rnd.nextInt())).ports(13337).start();
 			PeerNAT uNat = new PeerBuilderNAT(unreachablePeer).start();
 			FutureRelayNAT startRelay = uNat.startRelay(clientConfig, peers[0].peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(startRelay.isSuccess());
-//			mockGCM(peers, uNat, startRelay.gcmMessageHandler());
+			// mockGCM(peers, uNat, startRelay.gcmMessageHandler());
 
 			System.out.print("Send direct message from unreachable peer");
 			final String request = "Hello ";
@@ -385,7 +388,7 @@ public class TestRelay {
 			FutureDirect fd = unreachablePeer.sendDirect(receiver.peerAddress()).object(request).start()
 					.awaitUninterruptibly();
 			Assert.assertEquals(response, fd.object());
-			
+
 			// make sure we did receive it from the unreachable peer with id
 			Assert.assertEquals(receiver.peerID(), fd.wrappedFuture().responseMessage().sender().peerId());
 		} finally {
@@ -429,7 +432,7 @@ public class TestRelay {
 			FutureRelayNAT startRelay = uNat.startRelay(clientConfig, peers[0].peerAddress());
 			FutureRelay frNAT = startRelay.awaitUninterruptibly().futureRelay();
 			Assert.assertTrue(startRelay.isSuccess());
-//			mockGCM(peers, uNat, startRelay.gcmMessageHandler());
+			// mockGCM(peers, uNat, startRelay.gcmMessageHandler());
 
 			PeerAddress relayPeer = frNAT.relays().iterator().next().relayAddress();
 			Peer found = null;
@@ -536,10 +539,11 @@ public class TestRelay {
 			new PeerBuilderNAT(master.peer()).addRelayServerConfiguration(relayType, serverConfig).start();
 
 			// Test setting up relay peers
-			unreachablePeer = new PeerBuilderDHT(new PeerBuilder(Number160.createHash(rnd.nextInt())).ports(13337).start()).start();
+			unreachablePeer = new PeerBuilderDHT(new PeerBuilder(Number160.createHash(rnd.nextInt())).ports(13337).start())
+					.start();
 			PeerNAT uNat = new PeerBuilderNAT(unreachablePeer.peer()).start();
 			uNat.startRelay(clientConfig, master.peerAddress());
-//			mockGCM(peers, uNat, startRelay.gcmMessageHandler());
+			// mockGCM(peers, uNat, startRelay.gcmMessageHandler());
 
 			FutureRelayNAT fbn = uNat.startRelay(clientConfig, master.peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(fbn.isSuccess());
@@ -547,10 +551,10 @@ public class TestRelay {
 			System.err.println("DONE!");
 
 		} finally {
-			if(master != null) {
+			if (master != null) {
 				master.shutdown().await();
 			}
-			if(unreachablePeer != null) {
+			if (unreachablePeer != null) {
 				unreachablePeer.shutdown().await();
 			}
 		}
@@ -576,14 +580,15 @@ public class TestRelay {
 
 			FutureRelayNAT fbn = uNat.startRelay(clientConfig, master.peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(fbn.isSuccess());
-//			mockGCM(peers, uNat, fbn.gcmMessageHandler());
+			// mockGCM(peers, uNat, fbn.gcmMessageHandler());
 
 			// wait for maintenance to kick in
 			waitMapUpdate();
 
 			printMapStatus(unreachablePeer, peers);
-			
-			FuturePut futurePut = peers[8].put(unreachablePeer.peerID()).data(new Data("hello")).start().awaitUninterruptibly();
+
+			FuturePut futurePut = peers[8].put(unreachablePeer.peerID()).data(new Data("hello")).start()
+					.awaitUninterruptibly();
 			// the relayed one is the slowest, so we need to wait for it!
 			futurePut.futureRequests().awaitUninterruptibly();
 			System.err.println(futurePut.failedReason());
@@ -627,7 +632,7 @@ public class TestRelay {
 			unreachablePeer.peer().bootstrap().peerAddress(master.peerAddress()).start();
 			FutureRelayNAT fbn = uNat.startRelay(clientConfig, master.peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(fbn.isSuccess());
-//			mockGCM(peers, uNat, fbn.gcmMessageHandler());
+			// mockGCM(peers, uNat, fbn.gcmMessageHandler());
 
 			// wait for maintenance to kick in
 			waitMapUpdate();
@@ -650,15 +655,16 @@ public class TestRelay {
 			Assert.assertTrue(unreachablePeer.storageLayer().contains(
 					new Number640(unreachablePeer.peerID(), Number160.ZERO, Number160.ZERO, Number160.ZERO)));
 
-			FutureGet futureGet = peers[8].get(unreachablePeer.peerID()).routingConfiguration(r).requestP2PConfiguration(rp).start().awaitUninterruptibly();
+			FutureGet futureGet = peers[8].get(unreachablePeer.peerID()).routingConfiguration(r).requestP2PConfiguration(rp)
+					.start().awaitUninterruptibly();
 			Assert.assertTrue(futureGet.isSuccess());
 
 			System.err.println("DONE!");
 		} finally {
-			if(master != null) {
+			if (master != null) {
 				master.shutdown().await();
 			}
-			if(unreachablePeer != null) {
+			if (unreachablePeer != null) {
 				unreachablePeer.shutdown().await();
 			}
 		}
@@ -679,12 +685,14 @@ public class TestRelay {
 			}
 
 			// Test setting up relay peers
-			unreachablePeer1 = new PeerBuilderDHT(new PeerBuilder(Number160.createHash(rnd.nextInt())).ports(13337).start()).start();
+			unreachablePeer1 = new PeerBuilderDHT(new PeerBuilder(Number160.createHash(rnd.nextInt())).ports(13337).start())
+					.start();
 			PeerNAT uNat1 = new PeerBuilderNAT(unreachablePeer1.peer()).start();
 			FutureRelayNAT fbn1 = uNat1.startRelay(clientConfig, master.peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(fbn1.isSuccess());
 
-			unreachablePeer2 = new PeerBuilderDHT(new PeerBuilder(Number160.createHash(rnd.nextInt())).ports(13338).start()).start();
+			unreachablePeer2 = new PeerBuilderDHT(new PeerBuilder(Number160.createHash(rnd.nextInt())).ports(13338).start())
+					.start();
 			PeerNAT uNat2 = new PeerBuilderNAT(unreachablePeer2.peer()).start();
 			FutureRelayNAT fbn2 = uNat2.startRelay(clientConfig, master.peerAddress()).awaitUninterruptibly();
 			Assert.assertTrue(fbn2.isSuccess());
@@ -692,12 +700,12 @@ public class TestRelay {
 			peers[8] = unreachablePeer1;
 			peers[9] = unreachablePeer2;
 			UtilsNAT.perfectRouting(peers);
-			
+
 			// wait for relay setup
 			Thread.sleep(5000);
-			
-//			mockGCM(peers, uNat1, fbn1.gcmMessageHandler());
-//			mockGCM(peers, uNat2, fbn2.gcmMessageHandler());
+
+			// mockGCM(peers, uNat1, fbn1.gcmMessageHandler());
+			// mockGCM(peers, uNat2, fbn2.gcmMessageHandler());
 			UtilsNAT.perfectRouting(peers);
 
 			// wait for maintenance to kick in
@@ -734,57 +742,59 @@ public class TestRelay {
 			System.err.println("DONE!");
 
 		} finally {
-			if(master != null) {
+			if (master != null) {
 				master.shutdown().await();
 			}
-			if(unreachablePeer1 != null) {
+			if (unreachablePeer1 != null) {
 				unreachablePeer1.shutdown().await();
 			}
-			if(unreachablePeer2 != null) {
+			if (unreachablePeer2 != null) {
 				unreachablePeer2.shutdown().await();
 			}
 		}
 	}
 
 	@Test
-    public void testRelayDHTPutGetSigned() throws Exception {
-        final Random rnd = new Random(42);
-         PeerDHT master = null;
-         PeerDHT unreachablePeer1 = null;
-         PeerDHT unreachablePeer2 = null;
-         try {
-        	PeerDHT[] peers = UtilsNAT.createNodesDHT(10, rnd, 4000);
-            master = peers[0]; // the relay peer
-            
-            for(PeerDHT peer:peers) {
+	public void testRelayDHTPutGetSigned() throws Exception {
+		final Random rnd = new Random(42);
+		PeerDHT master = null;
+		PeerDHT unreachablePeer1 = null;
+		PeerDHT unreachablePeer2 = null;
+		try {
+			PeerDHT[] peers = UtilsNAT.createNodesDHT(10, rnd, 4000);
+			master = peers[0]; // the relay peer
+
+			for (PeerDHT peer : peers) {
 				new PeerBuilderNAT(peer.peer()).addRelayServerConfiguration(relayType, serverConfig).start();
-            }
-             
-            KeyPairGenerator gen = KeyPairGenerator.getInstance("DSA");
-            KeyPair pair1 = gen.generateKeyPair();
-            KeyPair pair2 = gen.generateKeyPair();
-             
-             // Test setting up relay peers
-            unreachablePeer1 = new PeerBuilderDHT(new PeerBuilder(Number160.createHash(rnd.nextInt())).keyPair(pair1).ports(13337).start()).start();
-            PeerNAT uNat1 = new PeerBuilderNAT(unreachablePeer1.peer()).start();
-            FutureRelayNAT fbn1 = uNat1.startRelay(clientConfig, master.peerAddress()).awaitUninterruptibly();
-            Assert.assertTrue(fbn1.isSuccess());
+			}
 
-            unreachablePeer2 = new PeerBuilderDHT(new PeerBuilder(Number160.createHash(rnd.nextInt())).keyPair(pair2).ports(13338).start()).start();
-            PeerNAT uNat2 = new PeerBuilderNAT(unreachablePeer2.peer()).start();
-            FutureRelayNAT fbn2 = uNat2.startRelay(clientConfig, master.peerAddress()).awaitUninterruptibly();
-            Assert.assertTrue(fbn2.isSuccess());
+			KeyPairGenerator gen = KeyPairGenerator.getInstance("DSA");
+			KeyPair pair1 = gen.generateKeyPair();
+			KeyPair pair2 = gen.generateKeyPair();
 
-            peers[8] = unreachablePeer1;
- 			peers[9] = unreachablePeer2;
- 			UtilsNAT.perfectRouting(peers);
- 			
- 			// wait for relay setup
+			// Test setting up relay peers
+			unreachablePeer1 = new PeerBuilderDHT(new PeerBuilder(Number160.createHash(rnd.nextInt())).keyPair(pair1)
+					.ports(13337).start()).start();
+			PeerNAT uNat1 = new PeerBuilderNAT(unreachablePeer1.peer()).start();
+			FutureRelayNAT fbn1 = uNat1.startRelay(clientConfig, master.peerAddress()).awaitUninterruptibly();
+			Assert.assertTrue(fbn1.isSuccess());
+
+			unreachablePeer2 = new PeerBuilderDHT(new PeerBuilder(Number160.createHash(rnd.nextInt())).keyPair(pair2)
+					.ports(13338).start()).start();
+			PeerNAT uNat2 = new PeerBuilderNAT(unreachablePeer2.peer()).start();
+			FutureRelayNAT fbn2 = uNat2.startRelay(clientConfig, master.peerAddress()).awaitUninterruptibly();
+			Assert.assertTrue(fbn2.isSuccess());
+
+			peers[8] = unreachablePeer1;
+			peers[9] = unreachablePeer2;
+			UtilsNAT.perfectRouting(peers);
+
+			// wait for relay setup
 			Thread.sleep(5000);
- 			
-// 			mockGCM(peers, uNat1, fbn1.gcmMessageHandler());
-// 			mockGCM(peers, uNat2, fbn2.gcmMessageHandler());
- 			UtilsNAT.perfectRouting(peers);
+
+			// mockGCM(peers, uNat1, fbn1.gcmMessageHandler());
+			// mockGCM(peers, uNat2, fbn2.gcmMessageHandler());
+			UtilsNAT.perfectRouting(peers);
 
 			// wait for maintenance to kick in
 			waitMapUpdate();
@@ -795,36 +805,40 @@ public class TestRelay {
 			RoutingConfiguration r = new RoutingConfiguration(5, 1, 1);
 			RequestP2PConfiguration rp = new RequestP2PConfiguration(1, 1, 0);
 
-            System.err.println(unreachablePeer1.peerID()); //..8bd
-            System.err.println(unreachablePeer2.peerID()); //..af3
-             
-            FuturePut futurePut = unreachablePeer1.put(unreachablePeer2.peerID()).data(new Data("hello")).sign().routingConfiguration(r).requestP2PConfiguration(rp).start().awaitUninterruptibly();
-            //the relayed one is the slowest, so we need to wait for it!
-            futurePut.futureRequests().awaitUninterruptibly();
-            System.err.println(futurePut.failedReason());
-             
-            Assert.assertTrue(futurePut.isSuccess());
-            Assert.assertTrue(unreachablePeer2.storageLayer().contains(new Number640(unreachablePeer2.peerID(), Number160.ZERO, Number160.ZERO, Number160.ZERO)));
-             
-            FutureGet futureGet = unreachablePeer1.get(unreachablePeer2.peerID()).routingConfiguration(r).sign().requestP2PConfiguration(rp).fastGet(false).start().awaitUninterruptibly();
-            //TODO: try peers even if no data found with fastget
-            System.err.println(futureGet.failedReason());
-            Assert.assertTrue(futureGet.isSuccess());
-             
-            //we cannot see the peer in futurePut.rawResult, as the relayed is the slowest and we finish earlier than that.
-            System.err.println("DONE!");
-         } finally {
-        	 if(master != null) {
- 				master.shutdown().await();
- 			}
- 			if(unreachablePeer1 != null) {
- 				unreachablePeer1.shutdown().await();
- 			}
- 			if(unreachablePeer2 != null) {
- 				unreachablePeer2.shutdown().await();
- 			}
-         }
-    }
+			System.err.println(unreachablePeer1.peerID()); // ..8bd
+			System.err.println(unreachablePeer2.peerID()); // ..af3
+
+			FuturePut futurePut = unreachablePeer1.put(unreachablePeer2.peerID()).data(new Data("hello")).sign()
+					.routingConfiguration(r).requestP2PConfiguration(rp).start().awaitUninterruptibly();
+			// the relayed one is the slowest, so we need to wait for it!
+			futurePut.futureRequests().awaitUninterruptibly();
+			System.err.println(futurePut.failedReason());
+
+			Assert.assertTrue(futurePut.isSuccess());
+			Assert.assertTrue(unreachablePeer2.storageLayer().contains(
+					new Number640(unreachablePeer2.peerID(), Number160.ZERO, Number160.ZERO, Number160.ZERO)));
+
+			FutureGet futureGet = unreachablePeer1.get(unreachablePeer2.peerID()).routingConfiguration(r).sign()
+					.requestP2PConfiguration(rp).fastGet(false).start().awaitUninterruptibly();
+			// TODO: try peers even if no data found with fastget
+			System.err.println(futureGet.failedReason());
+			Assert.assertTrue(futureGet.isSuccess());
+
+			// we cannot see the peer in futurePut.rawResult, as the relayed is the slowest and we finish
+			// earlier than that.
+			System.err.println("DONE!");
+		} finally {
+			if (master != null) {
+				master.shutdown().await();
+			}
+			if (unreachablePeer1 != null) {
+				unreachablePeer1.shutdown().await();
+			}
+			if (unreachablePeer2 != null) {
+				unreachablePeer2.shutdown().await();
+			}
+		}
+	}
 
 	@Test
 	public void testVeryFewPeers() throws Exception {
@@ -855,10 +869,10 @@ public class TestRelay {
 	}
 
 	private Collection<PeerAddress> getNeighbors(Peer peer) {
-		if(peer == null) {
+		if (peer == null) {
 			return Collections.emptyList();
 		}
-		
+
 		Map<Number320, DispatchHandler> handlers = peer.connectionBean().dispatcher().searchHandler(5);
 		for (Map.Entry<Number320, DispatchHandler> entry : handlers.entrySet()) {
 			if (entry.getValue() instanceof BaseRelayServer) {


### PR DESCRIPTION
This is an intermediate solution between the pure TCP approach (unbuffered, forward every request directly) and the GCM approach (buffer requests at relay peer, Android-only).
The new approach has a steady TCP connection to the unreachable peer but buffers requests before forwarding them. It may be more energy-conserving than forwarding every message at once.

I added some test-cases and deployed it successfully onto an Android device.