### PR TITLE
Added possibility to filter replication

### DIFF
--- a/replication/src/main/java/net/tomp2p/replication/IndirectReplication.java
+++ b/replication/src/main/java/net/tomp2p/replication/IndirectReplication.java
@@ -18,6 +18,7 @@ package net.tomp2p.replication;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -68,6 +69,7 @@ public class IndirectReplication implements ResponsibilityListener, Runnable {
     private boolean nRoot = false;
     private boolean keepData = false;
     private Replication replication;
+    private Collection<ReplicationFilter> replicationFilters = new HashSet<ReplicationFilter>();
     
     private ScheduledFuture<?> scheduledFuture;
     
@@ -189,6 +191,23 @@ public class IndirectReplication implements ResponsibilityListener, Runnable {
     	return blockSize;
     }
     
+	public IndirectReplication addReplicationFilter(ReplicationFilter filter) {
+		if (replicationFilters == null) {
+			replicationFilters = new HashSet<ReplicationFilter>(1);
+		}
+		replicationFilters.add(filter);
+		return this;
+	}
+
+	public Collection<ReplicationFilter> replicationFilters() {
+		return replicationFilters;
+	}
+
+	public IndirectReplication replicationFilters(Collection<ReplicationFilter> replicationFilters) {
+		this.replicationFilters = replicationFilters;
+		return this;
+	}
+    
     public IndirectReplication start() {
     	
     	if (intervalMillis == -1) {
@@ -212,7 +231,11 @@ public class IndirectReplication implements ResponsibilityListener, Runnable {
 			};
     	}
     	
-    	this.replication = new Replication(peer, replicationFactor.replicationFactor(), nRoot, keepData);
+    	if(replicationFilters == null) {
+    		replicationFilters = new HashSet<ReplicationFilter>(0);
+    	}
+    	
+    	this.replication = new Replication(peer, replicationFactor.replicationFactor(), nRoot, keepData, replicationFilters);
     	this.replication.addResponsibilityListener(this);
     	if(responsibilityListeners!=null) {
     		for(ResponsibilityListener responsibilityListener:responsibilityListeners) {
@@ -344,6 +367,10 @@ public class IndirectReplication implements ResponsibilityListener, Runnable {
         int count = 0;
         List<FutureDone<?>> retVal = new ArrayList<FutureDone<?>>(replicationFactor);
         for (PeerStatistic peerStatistic : sortedSet) {
+        	if(replication.rejectReplication(peerStatistic.peerAddress())) {
+        		continue;
+        	}
+        	
             count++;
             closePeers.add(peerStatistic.peerAddress());
             retVal.add(replicationSender.sendDirect(peerStatistic.peerAddress(), locationKey, dataMapConverted));

--- a/replication/src/main/java/net/tomp2p/replication/ReplicationFilter.java
+++ b/replication/src/main/java/net/tomp2p/replication/ReplicationFilter.java
@@ -1,0 +1,13 @@
+package net.tomp2p.replication;
+
+import net.tomp2p.peers.PeerAddress;
+
+/**
+ * Allows to filter peers that should not be considered for the replication
+ * @author Nico Rutishauser
+ *
+ */
+public interface ReplicationFilter {
+
+	boolean rejectReplication(PeerAddress targetAddress);
+}

--- a/replication/src/main/java/net/tomp2p/replication/SlowReplicationFilter.java
+++ b/replication/src/main/java/net/tomp2p/replication/SlowReplicationFilter.java
@@ -1,0 +1,18 @@
+package net.tomp2p.replication;
+
+import net.tomp2p.peers.PeerAddress;
+
+/**
+ * Relieves slow peers from the replication duty
+ * 
+ * @author Nico Rutishauser
+ *
+ */
+public class SlowReplicationFilter implements ReplicationFilter {
+
+	@Override
+	public boolean rejectReplication(PeerAddress targetAddress) {
+		return targetAddress.isSlow();
+	}
+
+}


### PR DESCRIPTION
Similar to a PostRoutingFilter, peers can now be filtered before the actual replication message is sent. This allows for example to exclude mobile peers (limited data usage).