### PR TITLE
avoid reflection 

### DIFF
--- a/core/src/main/java/net/tomp2p/storage/Data.java
+++ b/core/src/main/java/net/tomp2p/storage/Data.java
@@ -26,6 +26,7 @@ import java.security.PublicKey;
 import java.security.SignatureException;
 import java.util.BitSet;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import net.tomp2p.connection.DSASignatureFactory;
@@ -816,7 +817,8 @@ public class Data {
 	 * @return The ByteBuffers that is the payload. We do not make a copy here
 	 */
 	public ByteBuffer[] toByteBuffers() {
-		return buffer.bufferList().toArray(new ByteBuffer[0]);
+		List<ByteBuffer> byteBuffers = buffer.bufferList();
+		return byteBuffers.toArray(new ByteBuffer[byteBuffers.size()]);
 	}
 
 	public PublicKey publicKey() {

--- a/core/src/main/java/net/tomp2p/storage/DataBuffer.java
+++ b/core/src/main/java/net/tomp2p/storage/DataBuffer.java
@@ -161,7 +161,7 @@ public class DataBuffer {
 		} else {
 			final DataBuffer copy = shallowCopyIntern();
 			//wrap does a slice, so a derived buffer, not increasing ref count
-			return Unpooled.wrappedBuffer(copy.buffers.toArray(new ByteBuf[0]));
+			return Unpooled.wrappedBuffer(copy.buffers.toArray(new ByteBuf[copy.buffers.size()]));
 		}
 	}
 


### PR DESCRIPTION
Avoids the slow reflection in toArray(...) needed to resize an undersized array to hold all objects in the collection. 