### PR TITLE
UDP/TCP switch for Discovery and Bootstrap builders

### DIFF
--- a/core/src/main/java/net/tomp2p/futures/FutureDiscover.java
+++ b/core/src/main/java/net/tomp2p/futures/FutureDiscover.java
@@ -75,7 +75,7 @@ public class FutureDiscover extends BaseFutureImpl<FutureDiscover> {
     }
 
     /**
-     * Gets called if the discovery was a success and an other peer could ping us with TCP and UDP.
+     * Gets called if the discovery was a success and an other peer could ping us with TCP and/or UDP.
      * 
      * @param ourPeerAddress
      *            The peerAddress of our server
@@ -187,9 +187,9 @@ public class FutureDiscover extends BaseFutureImpl<FutureDiscover> {
         
         @Override
         public void run() {
-        	failed(serverPeerAddress, "Timeout in Discover: " +
-                    (System.currentTimeMillis() - start) + "ms. Seems like pingTCPProbe or pingUDPProbe did not " +
-                    "succeed in time. However my address reported from pingTCPDiscover is " + serverPeerAddress);
+            failed(serverPeerAddress, "Timeout in Discover: " + (System.currentTimeMillis() - start)
+                    + "ms. Seems like pingTCPProbe or pingUDPProbe did not succeed in time."
+                    + " However my address reported from pingDiscover is " + serverPeerAddress);
         }
     }
     

--- a/core/src/main/java/net/tomp2p/p2p/builder/DiscoverBuilder.java
+++ b/core/src/main/java/net/tomp2p/p2p/builder/DiscoverBuilder.java
@@ -18,10 +18,8 @@ package net.tomp2p.p2p.builder;
 
 import java.net.InetAddress;
 import java.util.Collection;
-
 import net.tomp2p.connection.Bindings;
 import net.tomp2p.connection.ChannelCreator;
-import net.tomp2p.connection.ConnectionConfiguration;
 import net.tomp2p.connection.DefaultConnectionConfiguration;
 import net.tomp2p.connection.DiscoverNetworks;
 import net.tomp2p.connection.DiscoverResults;
@@ -29,9 +27,7 @@ import net.tomp2p.connection.Ports;
 import net.tomp2p.futures.BaseFutureAdapter;
 import net.tomp2p.futures.FutureChannelCreator;
 import net.tomp2p.futures.FutureDiscover;
-import net.tomp2p.futures.FutureDone;
 import net.tomp2p.futures.FutureResponse;
-import net.tomp2p.futures.Futures;
 import net.tomp2p.message.Message.Type;
 import net.tomp2p.p2p.Peer;
 import net.tomp2p.p2p.PeerReachable;
@@ -44,7 +40,7 @@ import net.tomp2p.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class DiscoverBuilder {
+public class DiscoverBuilder extends DefaultConnectionConfiguration {
     final private static Logger LOG = LoggerFactory.getLogger(DiscoverBuilder.class);
 
     final private static FutureDiscover FUTURE_DISCOVER_SHUTDOWN = new FutureDiscover()
@@ -62,10 +58,8 @@ public class DiscoverBuilder {
 
     private int discoverTimeoutSec = 5;
 
-    private ConnectionConfiguration configuration;
-    
     private FutureDiscover futureDiscover;
-    
+
     private boolean expectManualForwarding;
 
     public DiscoverBuilder(Peer peer) {
@@ -160,17 +154,22 @@ public class DiscoverBuilder {
     public DiscoverBuilder expectManualForwarding() {
         return setExpectManualForwarding(true);
     }
-    
+
     public DiscoverBuilder setExpectManualForwarding(boolean expectManualForwarding) {
         this.expectManualForwarding = expectManualForwarding;
         return this;
     }
 
+    /**
+     * @return The future discover. This future holds also the real ID of the peer we send the discover request
+     */
     public FutureDiscover start() {
         if (peer.isShutdown()) {
             return FUTURE_DISCOVER_SHUTDOWN;
         }
-
+        if (forceTCP && forceUDP) {
+            throw new IllegalArgumentException("Only one of 'forceTCP' or 'forceUDP' can be chosen.");
+        }
         if (peerAddress == null && inetAddress != null) {
         	PeerSocket4Address psa = PeerSocket4Address.builder().ipv4(IPv4.fromInet4Address(inetAddress)).tcpPort(portTCP).udpPort(portUDP).build();
         	peerAddress = PeerAddress.builder().ipv4Socket(psa).peerId(Number160.ZERO).build();
@@ -178,13 +177,10 @@ public class DiscoverBuilder {
         if (peerAddress == null) {
             throw new IllegalArgumentException("Peer address or inet address required.");
         }
-        if (configuration == null) {
-            configuration = new DefaultConnectionConfiguration();
-        }
         if (futureDiscover == null) {
         	futureDiscover = new FutureDiscover();
         }
-        return discover(peerAddress, configuration, futureDiscover);
+        return discover(peerAddress);
     }
 
     /**
@@ -194,17 +190,25 @@ public class DiscoverBuilder {
      * 
      * @param peerAddress
      *            The peer address. Since pings are used the peer ID can be Number160.ZERO
-     * @return The future discover. This future holds also the real ID of the peer we send the discover request
+     * @return The future discover.
      */
-    private FutureDiscover discover(final PeerAddress peerAddress, final ConnectionConfiguration configuration, 
-    		final FutureDiscover futureDiscover) {
-        FutureChannelCreator fcc = peer.connectionBean().reservation().create(1, 2);
+    private FutureDiscover discover(final PeerAddress peerAddress) {
+        FutureChannelCreator fcc;
+        if (forceUDP) {
+            //Only reserve udp channels
+            fcc = peer.connectionBean().reservation().create(2, 0);
+        } else if (forceTCP) {
+            //Only reserve tcp channels
+            fcc = peer.connectionBean().reservation().create(0, 2);
+        } else {
+            fcc = peer.connectionBean().reservation().create(1, 2);
+        }
         Utils.addReleaseListener(fcc, futureDiscover);
         fcc.addListener(new BaseFutureAdapter<FutureChannelCreator>() {
             @Override
             public void operationComplete(final FutureChannelCreator future) throws Exception {
                 if (future.isSuccess()) {
-                    discover(futureDiscover, peerAddress, future.channelCreator(), configuration);
+                    pingDiscover(peerAddress, future.channelCreator());
                 } else {
                     futureDiscover.failed(future);
                 }
@@ -214,73 +218,73 @@ public class DiscoverBuilder {
     }
 
     /**
-     * Needs 3 connections. Cleans up ChannelCreator, which means they will be released.
+     * Starts the discovery process.
+     *
+     * First launch a pingDiscover to setup our addresses then probe our reachability.
+     *
+     * Cleans up ChannelCreator, which means they will be released.
      * 
      * @param peerAddress
      * @param cc
      * @return
      */
-    private void discover(final FutureDiscover futureDiscover, final PeerAddress peerAddress,
-            final ChannelCreator cc, final ConnectionConfiguration configuration) {
-    	LOG.debug("starting discover to {}",peerAddress);
-    	final FutureDone<Void> pingDone = new FutureDone<Void>();
+    private void pingDiscover(final PeerAddress peerAddress, final ChannelCreator cc) {
+        LOG.debug("starting discover to {}", peerAddress);
 
-        peer.pingRPC().addPeerReachableListener(new PeerReachable() {
-            private volatile boolean changedUDP = false;
-            private volatile boolean changedTCP = false;
+        final PeerReachable reachableListener = new PeerReachable() {
 
             @Override
-            public void peerWellConnected(final PeerAddress peerAddress, final PeerAddress reporter, final boolean tcp) {
-            	pingDone.addListener(new BaseFutureAdapter<FutureDone<Void>>() {
-					@Override
-					public void operationComplete(FutureDone<Void> future) throws Exception {
-						if (tcp) {
-		            		futureDiscover.discoveredTCP();
-		            		changedTCP = true;
-		            		LOG.debug("TCP discovered");
-		            	} else {
-		            		futureDiscover.discoveredUDP();
-		            		changedUDP = true;
-		            		LOG.debug("UDP discovered");
-		            	}
-						if (changedTCP && changedUDP) {
-		                    futureDiscover.done(peerAddress, reporter);
-		                }
-					}
-				});
-                
+            public void peerWellConnected(final PeerAddress peerAddress, final PeerAddress reporter,
+                    final boolean tcp) {
+                LOG.info("peerWellConnected.");
+                if (tcp) {
+                    futureDiscover.discoveredTCP();
+                    LOG.debug("TCP discovered");
+                } else {
+                    futureDiscover.discoveredUDP();
+                    LOG.debug("UDP discovered");
+                }
+                if (futureDiscover.isDiscoveredTCP() && forceTCP) {
+                    //If we forced TCP, assume we only wait for the TCP response to finish
+                    futureDiscover.done(peerAddress, reporter);
+                } else if (futureDiscover.isDiscoveredUDP() && forceUDP) {
+                    //If we forced UDP, assume we only wait for the UDP response to finish
+                    futureDiscover.done(peerAddress, reporter);
+                } else if (futureDiscover.isDiscoveredTCP() && futureDiscover.isDiscoveredUDP()) {
+                    futureDiscover.done(peerAddress, reporter);
+                }
             }
-        });
+        };
+        peer.pingRPC().addPeerReachableListener(reachableListener);
+        //Shoudn't the Reachable listener be removed once done() ? 
 
-        final FutureResponse futureResponseTCP = peer.pingRPC().pingTCPDiscover(peerAddress, cc,
-                configuration);
-        
-        futureResponseTCP.addListener(new BaseFutureAdapter<FutureResponse>() {
+        final FutureResponse futureResponse;
+        if (forceUDP) {
+            futureResponse = peer.pingRPC().pingUDPDiscover(peerAddress, cc, this);
+        } else {
+            //ping discover by default with tcp
+            futureResponse = peer.pingRPC().pingTCPDiscover(peerAddress, cc, this);
+        }
+
+        futureResponse.addListener(new BaseFutureAdapter<FutureResponse>() {
             @Override
             public void operationComplete(FutureResponse future) throws Exception {
                 PeerAddress serverAddress = peer.peerBean().serverPeerAddress();
-                if (futureResponseTCP.isSuccess() && futureResponseTCP.responseMessage().type() == Type.NOT_FOUND) {
+                if (futureResponse.isSuccess() && futureResponse.responseMessage().type() == Type.NOT_FOUND) {
                 	//this was a ping to myself. This is pointless
-                	futureDiscover.failed("FutureDiscover to yourself",
-                            futureResponseTCP);
-                    return;
-                }
-                else if (futureResponseTCP.isSuccess()) {
-                	//now we know our internal address, set it as it could be a wrong one, e.g. 127.0.0.1
-                	serverAddress = serverAddress.withIpv4Socket(futureResponseTCP.responseMessage().recipient().ipv4Socket());
-                	
-                    Collection<PeerAddress> tmp = futureResponseTCP.responseMessage().neighborsSet(0)
+                	futureDiscover.failed("FutureDiscover to yourself", futureResponse);
+                } else if (futureResponse.isSuccess()) {
+                    Collection<PeerAddress> tmp = futureResponse.responseMessage().neighborsSet(0)
                             .neighbors();
-                    futureDiscover.reporter(futureResponseTCP.responseMessage().sender());
+                    futureDiscover.reporter(futureResponse.responseMessage().sender());
                     if (tmp.size() == 1) {
                         PeerAddress seenAs = tmp.iterator().next();
                         LOG.info("This peer is seen as {} by peer {}. This peer sees itself as {}.",
                                 seenAs, peerAddress, peer.peerAddress());
                         if (!peer.peerAddress().ipv4Socket().equalsWithoutPorts(seenAs.ipv4Socket())) {
-                            // check if we have this interface in that we can
-                            // listen to
+                            // check if we have this interface in that we can listen to
                             Bindings bindings2 = new Bindings().addAddress(seenAs.ipv4Socket().ipv4().toInetAddress());
-                          
+
                             DiscoverResults discoverResults = DiscoverNetworks.discoverInterfaces(bindings2);
                             String status = discoverResults.status();
                             LOG.info("2nd interface discovery: {}", status);
@@ -290,75 +294,102 @@ public class DiscoverBuilder {
                                 peer.peerBean().serverPeerAddress(serverAddress);
                                 LOG.info("This peer had the wrong interface. Changed it to {}.", serverAddress);
                             } else {
-                                // now we know our internal IP, where we receive
-                                // packets
+                                // now we know our internal IP, where we receive packets
                                 final Ports ports = peer.connectionBean().channelServer().channelServerConfiguration().portsForwarding();
                                 if (ports.isManualPort()) {
                                 	final PeerAddress serverAddressOrig = serverAddress;
-                                	PeerSocket4Address serverSocket = serverAddress.ipv4Socket();
+                                    PeerSocket4Address serverSocket = serverAddress.ipv4Socket();
                                 	serverSocket = serverSocket.withTcpPort(ports.tcpPort()).withUdpPort(ports.udpPort());
                                 	serverSocket = serverSocket.withIpv4(seenAs.ipv4Socket().ipv4());
                                     //manual port forwarding detected, set flag
-                                    peer.peerBean().serverPeerAddress(serverAddress.withIpv4Socket(serverSocket).withIpInternalSocket(serverAddressOrig.ipv4Socket()));
+                                    peer.peerBean().serverPeerAddress(serverAddress.withIpv4Socket(serverSocket).
+                                            withNet4Internal(true).withIpInternalSocket(serverAddressOrig.ipv4Socket()));
                                     LOG.info("manual ports, change it to: {}", serverAddress);
                                 } else if(expectManualForwarding) {
                                 	final PeerAddress serverAddressOrig = serverAddress;
                                 	PeerSocket4Address serverSocket = serverAddress.ipv4Socket();
                                 	serverSocket = serverSocket.withIpv4(seenAs.ipv4Socket().ipv4());
-                                	peer.peerBean().serverPeerAddress(serverAddress.withIpv4Socket(serverSocket).withIpInternalSocket(serverAddressOrig.ipv4Socket()));
+                                    peer.peerBean().serverPeerAddress(serverAddress.withIpv4Socket(serverSocket)
+                                            .withNet4Internal(true).withIpInternalSocket(serverAddressOrig.ipv4Socket()));
                                     LOG.info("we were manually forwarding, change it to: {}", serverAddress);
-                                }
-                                else {
+                                } else {
                                     // we need to find a relay, because there is a NAT in the way.
                                 	// we cannot use futureResponseTCP.responseMessage().recipient() as this may return also IPv6 addresses
                                 	LOG.info("We are most likely behind NAT, try to UPNP, NATPMP or relay. PeerAddress: {}, ServerAddress: {}, Seen as: {}" + peerAddress, serverAddress, seenAs);
                                     futureDiscover.externalHost("We are most likely behind NAT, try to UPNP, NATPMP or relay. Using peerAddress " + peerAddress, serverAddress.ipv4Socket(), seenAs.ipv4Socket());
-                                    return;
                                 }
                             }
                         }
-                        // else -> we announce exactly how the other peer sees
-                        // us
-                        FutureResponse fr1 = peer.pingRPC().pingTCPProbe(peerAddress, cc,
-                                configuration);
-                        fr1.addListener(new BaseFutureAdapter<FutureResponse>() {
-							@Override
-                            public void operationComplete(FutureResponse future) throws Exception {
-	                            if(future.isFailed() ) {
-	                            	LOG.warn("FutureDiscover (2): We need at least the TCP connection {} - {}", future, futureDiscover.failedReason());
-	                            	futureDiscover.failed("FutureDiscover (2): We need at least the TCP connection", future);
-	                            }
-                            }
-						});
-                        FutureResponse fr2 = peer.pingRPC().pingUDPProbe(peerAddress, cc,
-                                configuration);
-                        fr2.addListener(new BaseFutureAdapter<FutureResponse>() {
-							@Override
-                            public void operationComplete(FutureResponse future) throws Exception {
-	                            if(future.isFailed() ) {
-	                            	LOG.warn("FutureDiscover (2): UDP failed connection {} - {}", future, futureDiscover.failedReason());
-	                            }
-                            }
-						});
-                        Futures.whenAll(fr1, fr2).addListener(new BaseFutureAdapter<FutureDone<FutureResponse[]>>() {
-							@Override
-							public void operationComplete(FutureDone<FutureResponse[]> future) throws Exception {
-								pingDone.done();
-							}
-						});
-                        // from here we probe, set the timeout here
+                        //Ask distant peer to reach us now that our internal and external addresses are (hopefully) correct
+                        pingProbe(cc);
+                        // from here we probe, set the timeout
                         futureDiscover.timeout(serverAddress, peer.connectionBean().timer(), discoverTimeoutSec);
-                        return;
                     } else {
                         futureDiscover.failed("Peer " + peerAddress + " did not report our IP address.");
-                        return;
                     }
                 } else {
-                    futureDiscover.failed("FutureDiscover (1): We need at least the TCP connection",
-                            futureResponseTCP);
-                    return;
+                    futureDiscover.failed("FutureDiscover (1): we need at least the first pingDiscover", futureResponse);
                 }
             }
         });
     }
+
+    /**
+     * Once the pingDiscover succeeded, probe our reachability with either TCP, UDP or both.
+     *
+     * @param cc
+     */
+    private void pingProbe(final ChannelCreator cc) {
+        if (forceUDP) {
+            //Only probe with UDP and finish discovery on success
+            FutureResponse frUdp = peer.pingRPC().pingUDPProbe(peerAddress, cc, DiscoverBuilder.this);
+            frUdp.addListener(new BaseFutureAdapter<FutureResponse>() {
+                @Override
+                public void operationComplete(FutureResponse future) throws Exception {
+                    if (future.isFailed()) {
+                        LOG.warn("FutureDiscover (2): We need the UDP connection with forceUDP {} - {}",
+                                future, futureDiscover.failedReason());
+                        futureDiscover.failed("FutureDiscover (2): We need the UDP connection with forceUDP", future);
+                    }
+                }
+            });
+        } else if (forceTCP) {
+            //Only probe with TCP and finish discovery on success
+            FutureResponse frTcp = peer.pingRPC().pingTCPProbe(peerAddress, cc, DiscoverBuilder.this);
+            frTcp.addListener(new BaseFutureAdapter<FutureResponse>() {
+                @Override
+                public void operationComplete(FutureResponse future) throws Exception {
+                    if (future.isFailed()) {
+                        LOG.warn("FutureDiscover (2): We need the TCP connection with forceTCP {} - {}",
+                                future, futureDiscover.failedReason());
+                        futureDiscover.failed("FutureDiscover (2): We need the TCP connection with forceTCP", future);
+                    }
+                }
+            });
+        } else {
+            //both TCP and UDP. Finish discovery after both calls returned, ignoring UDP failure
+            FutureResponse fr1 = peer.pingRPC().pingTCPProbe(peerAddress, cc, DiscoverBuilder.this);
+            fr1.addListener(new BaseFutureAdapter<FutureResponse>() {
+                @Override
+                public void operationComplete(FutureResponse future) throws Exception {
+                    if (future.isFailed()) {
+                        LOG.warn("FutureDiscover (2): We need at least the TCP connection {} - {}",
+                                future, futureDiscover.failedReason());
+                        futureDiscover.failed("FutureDiscover (2): We need at least the TCP connection", future);
+                    }
+                }
+            });
+            FutureResponse fr2 = peer.pingRPC().pingUDPProbe(peerAddress, cc, DiscoverBuilder.this);
+            fr2.addListener(new BaseFutureAdapter<FutureResponse>() {
+                @Override
+                public void operationComplete(FutureResponse future) throws Exception {
+                    if (future.isFailed()) {
+                        LOG.warn("FutureDiscover (2): UDP failed connection {} - {}",
+                                future, futureDiscover.failedReason());
+                    }
+                }
+            });
+        }
+    }
+
 }

--- a/core/src/main/java/net/tomp2p/rpc/PingRPC.java
+++ b/core/src/main/java/net/tomp2p/rpc/PingRPC.java
@@ -191,8 +191,8 @@ public class PingRPC extends DispatchHandler {
 	 * @param remotePeer
 	 *            The destination peer
 	 * @param channelCreator
-	 *            The channel creator where we create a UPD channel
-	 * @return The future that will be triggered when we receive an answer or something fails.
+	 *            The channel creator where we create a UDP channel
+   	 * @return The future that will be triggered when we receive an answer or something fails.
 	 */
 	public FutureResponse pingUDPDiscover(final PeerAddress remotePeer, final ChannelCreator channelCreator,
 			final ConnectionConfiguration configuration) {


### PR DESCRIPTION

Added UDP/TCP switch for Discovery and Bootstrap builders as discussed previously.

Also corrected a small error in discovery when using manual ports (or setting expectManualForwarding) resulting in the internal IP address to be ignored.

Tested with both TCP and UDP between two distant, NAT'ed nodes. Special discovery cases should be tested.