### PR TITLE
Tomp2p parent 5.0 beta8.1

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>net.tomp2p</groupId>
 		<artifactId>tomp2p-parent</artifactId>
-		<version>5.0-Beta8</version>
+		<version>5.0-Beta8.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>tomp2p-all</artifactId>

--- a/android/pom.xml
+++ b/android/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
     	<groupId>net.tomp2p</groupId>
     	<artifactId>tomp2p-parent</artifactId>
-    	<version>5.0-Beta8</version>
+    	<version>5.0-Beta8.1-SNAPSHOT</version>
   	</parent>
 	
 	<artifactId>tomp2p-android</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>net.tomp2p</groupId>
 		<artifactId>tomp2p-parent</artifactId>
-		<version>5.0-Beta8</version>
+		<version>5.0-Beta8.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>tomp2p-core</artifactId>

--- a/core/src/main/java/net/tomp2p/storage/AlternativeCompositeByteBuf.java
+++ b/core/src/main/java/net/tomp2p/storage/AlternativeCompositeByteBuf.java
@@ -27,10 +27,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.SlicedByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
-import io.netty.util.CharsetUtil;
-import io.netty.util.IllegalReferenceCountException;
-import io.netty.util.ResourceLeak;
-import io.netty.util.ResourceLeakDetector;
+import io.netty.util.*;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
@@ -41,6 +38,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.CharBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.nio.charset.CharacterCodingException;
@@ -199,6 +197,16 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 				break;
 			}
 		}
+		return this;
+	}
+
+	@Override
+	public ByteBuf touch() {
+		return this;
+	}
+
+	@Override
+	public ByteBuf touch(Object hint) {
 		return this;
 	}
 
@@ -361,6 +369,16 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 			return false;
 		}
 		throw new RuntimeException("don't know what to report, Netty does not expose this");
+	}
+
+	@Override
+	public boolean isReadOnly() {
+		return false;
+	}
+
+	@Override
+	public ByteBuf asReadOnly() {
+		return null;
 	}
 
 	@Override
@@ -715,8 +733,18 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public short getShortLE(int index) {
+		return 0;
+	}
+
+	@Override
 	public int getUnsignedShort(int index) {
 		return getShort(index) & 0xFFFF;
+	}
+
+	@Override
+	public int getUnsignedShortLE(int index) {
+		return 0;
 	}
 
 	@Override
@@ -729,6 +757,11 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public int getMediumLE(int index) {
+		return 0;
+	}
+
+	@Override
 	public int getUnsignedMedium(int index) {
 		Component c = findComponent(index);
 		if (index + 3 <= c.endOffset()) {
@@ -738,6 +771,11 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 		} else {
 			return getShort(index) & 0xFFFF | (getByte(index + 2) & 0xFF) << 16;
 		}
+	}
+
+	@Override
+	public int getUnsignedMediumLE(int index) {
+		return 0;
 	}
 
 	@Override
@@ -755,8 +793,18 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public int getIntLE(int index) {
+		return 0;
+	}
+
+	@Override
 	public long getUnsignedInt(int index) {
 		return getInt(index) & 0xFFFFFFFFL;
+	}
+
+	@Override
+	public long getUnsignedIntLE(int index) {
+		return 0;
 	}
 
 	@Override
@@ -771,6 +819,11 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 			return getInt(index) & 0xFFFFFFFFL
 					| (getInt(index + 4) & 0xFFFFFFFFL) << 32;
 		}
+	}
+
+	@Override
+	public long getLongLE(int index) {
+		return 0;
 	}
 
 	@Override
@@ -943,6 +996,16 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
+		return 0;
+	}
+
+	@Override
+	public CharSequence getCharSequence(int index, int length, Charset charset) {
+		return null;
+	}
+
+	@Override
 	public AlternativeCompositeByteBuf setBoolean(int index, boolean value) {
 		setByte(index, value ? 1 : 0);
 		return this;
@@ -971,6 +1034,11 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public ByteBuf setShortLE(int index, int value) {
+		return null;
+	}
+
+	@Override
 	public AlternativeCompositeByteBuf setMedium(int index, int value) {
 		Component c = findComponent(index);
 		if (index + 3 <= c.endOffset()) {
@@ -983,6 +1051,11 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 			setByte(index + 2, (byte) (value >>> 16));
 		}
 		return this;
+	}
+
+	@Override
+	public ByteBuf setMediumLE(int index, int value) {
+		return null;
 	}
 
 	@Override
@@ -1001,6 +1074,11 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public ByteBuf setIntLE(int index, int value) {
+		return null;
+	}
+
+	@Override
 	public AlternativeCompositeByteBuf setLong(int index, long value) {
 		Component c = findComponent(index);
 		if (index + 8 <= c.endOffset()) {
@@ -1013,6 +1091,11 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 			setInt(index + 4, (int) (value >>> 32));
 		}
 		return this;
+	}
+
+	@Override
+	public ByteBuf setLongLE(int index, long value) {
+		return null;
 	}
 
 	@Override
@@ -1232,6 +1315,11 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
+		return 0;
+	}
+
+	@Override
 	public AlternativeCompositeByteBuf setZero(int index, int length) {
 		if (length == 0) {
 			return this;
@@ -1261,6 +1349,11 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 			}
 		}
 		return this;
+	}
+
+	@Override
+	public int setCharSequence(int index, CharSequence sequence, Charset charset) {
+		return 0;
 	}
 
 	/**
@@ -1308,8 +1401,18 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public short readShortLE() {
+		return 0;
+	}
+
+	@Override
 	public int readUnsignedShort() {
 		return readShort() & 0xFFFF;
+	}
+
+	@Override
+	public int readUnsignedShortLE() {
+		return 0;
 	}
 
 	@Override
@@ -1322,11 +1425,21 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public int readMediumLE() {
+		return 0;
+	}
+
+	@Override
 	public int readUnsignedMedium() {
 		checkReadableBytes(3);
 		int v = getUnsignedMedium(readerIndex);
 		readerIndex += 3;
 		return v;
+	}
+
+	@Override
+	public int readUnsignedMediumLE() {
+		return 0;
 	}
 
 	@Override
@@ -1338,8 +1451,18 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public int readIntLE() {
+		return 0;
+	}
+
+	@Override
 	public long readUnsignedInt() {
 		return readInt() & 0xFFFFFFFFL;
+	}
+
+	@Override
+	public long readUnsignedIntLE() {
+		return 0;
 	}
 
 	@Override
@@ -1348,6 +1471,11 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 		long v = getLong(readerIndex);
 		readerIndex += 8;
 		return v;
+	}
+
+	@Override
+	public long readLongLE() {
+		return 0;
 	}
 
 	@Override
@@ -1385,6 +1513,11 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 		ByteBuf slice = slice(readerIndex, length);
 		readerIndex += length;
 		return slice;
+	}
+
+	@Override
+	public ByteBuf readRetainedSlice(int length) {
+		return null;
 	}
 
 	@Override
@@ -1452,6 +1585,16 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 		int readBytes = getBytes(readerIndex, out, length);
 		readerIndex += readBytes;
 		return readBytes;
+	}
+
+	@Override
+	public CharSequence readCharSequence(int length, Charset charset) {
+		return null;
+	}
+
+	@Override
+	public int readBytes(FileChannel out, long position, int length) throws IOException {
+		return 0;
 	}
 
 	@Override
@@ -1542,11 +1685,21 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public ByteBuf writeShortLE(int value) {
+		return null;
+	}
+
+	@Override
 	public ByteBuf writeMedium(int value) {
 		ensureWritable0(3, true);
 		setMedium(writerIndex, value);
 		increaseComponentWriterIndex(3);
 		return this;
+	}
+
+	@Override
+	public ByteBuf writeMediumLE(int value) {
+		return null;
 	}
 
 	@Override
@@ -1558,11 +1711,21 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public ByteBuf writeIntLE(int value) {
+		return null;
+	}
+
+	@Override
 	public ByteBuf writeLong(long value) {
 		ensureWritable0(8, true);
 		setLong(writerIndex, value);
 		increaseComponentWriterIndex(8);
 		return this;
+	}
+
+	@Override
+	public ByteBuf writeLongLE(long value) {
+		return null;
 	}
 
 	@Override
@@ -1655,6 +1818,11 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public int writeBytes(FileChannel in, long position, int length) throws IOException {
+		return 0;
+	}
+
+	@Override
 	public ByteBuf writeZero(int length) {
 		if (length == 0) {
 			return this;
@@ -1684,6 +1852,11 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public int writeCharSequence(CharSequence sequence, Charset charset) {
+		return 0;
+	}
+
+	@Override
 	public int indexOf(int fromIndex, int toIndex, byte value) {
 		return ByteBufUtil.indexOf(this, fromIndex, toIndex, value);
 	}
@@ -1709,20 +1882,20 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
-	public int forEachByte(ByteBufProcessor processor) {
+	public int forEachByte(ByteProcessor processor) {
 		int index = readerIndex;
 		int length = writerIndex - index;
 		return forEachByteAsc0(index, length, processor);
 	}
 
 	@Override
-	public int forEachByte(int index, int length, ByteBufProcessor processor) {
+	public int forEachByte(int index, int length, ByteProcessor processor) {
 		checkIndex(index, length);
 		return forEachByteAsc0(index, length, processor);
 	}
 
 	private int forEachByteAsc0(int index, int length,
-			ByteBufProcessor processor) {
+								ByteProcessor processor) {
 		if (processor == null) {
 			throw new NullPointerException("processor");
 		}
@@ -1749,20 +1922,20 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
-	public int forEachByteDesc(ByteBufProcessor processor) {
+	public int forEachByteDesc(ByteProcessor processor) {
 		int index = readerIndex;
 		int length = writerIndex - index;
 		return forEachByteDesc0(index, length, processor);
 	}
 
 	@Override
-	public int forEachByteDesc(int index, int length, ByteBufProcessor processor) {
+	public int forEachByteDesc(int index, int length, ByteProcessor processor) {
 		checkIndex(index, length);
 		return forEachByteDesc0(index, length, processor);
 	}
 
 	private int forEachByteDesc0(int index, int length,
-			ByteBufProcessor processor) {
+								 ByteProcessor processor) {
 		if (processor == null) {
 			throw new NullPointerException("processor");
 		}
@@ -1828,6 +2001,11 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public ByteBuf retainedSlice() {
+		return null;
+	}
+
+	@Override
 	public ByteBuf slice(int index, int length) {
 		if (length == 0) {
 			return Unpooled.EMPTY_BUFFER;
@@ -1837,8 +2015,18 @@ public class AlternativeCompositeByteBuf extends ByteBuf {
 	}
 
 	@Override
+	public ByteBuf retainedSlice(int index, int length) {
+		return null;
+	}
+
+	@Override
 	public ByteBuf duplicate() {
 		return new DuplicatedByteBuf(this);
+	}
+
+	@Override
+	public ByteBuf retainedDuplicate() {
+		return null;
 	}
 
 	@Override

--- a/dht/pom.xml
+++ b/dht/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>net.tomp2p</groupId>
 		<artifactId>tomp2p-parent</artifactId>
-		<version>5.0-Beta8</version>
+		<version>5.0-Beta8.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>tomp2p-dht</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
     	<groupId>net.tomp2p</groupId>
     	<artifactId>tomp2p-parent</artifactId>
-    	<version>5.0-Beta8</version>
+    	<version>5.0-Beta8.1-SNAPSHOT</version>
   	</parent>
 	
 	<artifactId>tomp2p-examples</artifactId>

--- a/nat/pom.xml
+++ b/nat/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>net.tomp2p</groupId>
 		<artifactId>tomp2p-parent</artifactId>
-		<version>5.0-Beta8</version>
+		<version>5.0-Beta8.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>tomp2p-nat</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<groupId>net.tomp2p</groupId>
 	<artifactId>tomp2p-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>5.0-Beta8</version>
+	<version>5.0-Beta8.1-SNAPSHOT</version>
 
 	<name>TomP2P</name>
 	<url>http://tomp2p.net</url>
@@ -34,7 +34,7 @@
 		<url>https://github.com/tomp2p/TomP2P</url>
 		<connection>scm:git:git://github.com/tomp2p/TomP2P.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/tomp2p/TomP2P.git</developerConnection>
-	  <tag>tomp2p-parent-5.0-Beta8</tag>
+	  <tag>tomp2p-parent-5.0-Beta8.1-SNAPSHOT</tag>
   	</scm>
   	
   	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   	</scm>
   	
   	<properties>
-        <netty.version>4.0.28.Final</netty.version>
+        <netty.version>4.1.45.Final</netty.version>
     </properties>
 
 	<modules>
@@ -187,7 +187,7 @@
 			</plugin>
 			<plugin>
       			<artifactId>maven-release-plugin</artifactId>
-      			<version>2.4.2</version>
+      			<version>2.5.3</version>
       			<dependencies>
         			<dependency>
           				<groupId>org.apache.maven.scm</groupId>

--- a/replication/pom.xml
+++ b/replication/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
     	<groupId>net.tomp2p</groupId>
     	<artifactId>tomp2p-parent</artifactId>
-    	<version>5.0-Beta8</version>
+    	<version>5.0-Beta8.1-SNAPSHOT</version>
   	</parent>
 	
 	<artifactId>tomp2p-replication</artifactId>

--- a/social/pom.xml
+++ b/social/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>net.tomp2p</groupId>
 		<artifactId>tomp2p-parent</artifactId>
-		<version>5.0-Beta8</version>
+		<version>5.0-Beta8.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>tomp2p-social</artifactId>

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>net.tomp2p</groupId>
 		<artifactId>tomp2p-parent</artifactId>
-		<version>5.0-Beta8</version>
+		<version>5.0-Beta8.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>tomp2p-storage</artifactId>

--- a/tracker/pom.xml
+++ b/tracker/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>net.tomp2p</groupId>
 		<artifactId>tomp2p-parent</artifactId>
-		<version>5.0-Beta8</version>
+		<version>5.0-Beta8.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>tomp2p-tracker</artifactId>


### PR DESCRIPTION
Upgraded Netty and maven-release-plugin versions.
_Take note:_
`AlternativeCompositeByteBuf` now contains a lot of unimplemented methods, seeing as the `ByteBug` interface changed. The only methods that were updated were the methods required to allow the project to compile.

I'm pretty sure we'll need to update these methods soon, as these unimplemented methods might cause unexpected behavior 